### PR TITLE
fix(webdav): correct sync-support detection, deletion status parsing,…

### DIFF
--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -11,6 +11,7 @@ use crate::caldav::types::{
 };
 use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
+use crate::webdav::types::http_status_code;
 
 pub use crate::webdav::client::RequestCompressionMode;
 
@@ -752,10 +753,8 @@ pub fn map_sync_response(
             continue;
         }
         let status = item.status.clone();
-        let is_deleted = status
-            .as_deref()
-            .map(|s| s.contains("404") || s.contains("410"))
-            .unwrap_or(false);
+        let code = status.as_deref().and_then(http_status_code);
+        let is_deleted = matches!(code, Some(404) | Some(410));
 
         out.push(SyncItem {
             href: item.href,

--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -11,6 +11,7 @@ use crate::carddav::types::{
 };
 use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
+use crate::webdav::types::http_status_code;
 
 pub use crate::webdav::client::RequestCompressionMode;
 
@@ -848,10 +849,8 @@ pub fn map_sync_response(
             continue;
         }
         let status = item.status.clone();
-        let is_deleted = status
-            .as_deref()
-            .map(|s| s.contains("404") || s.contains("410"))
-            .unwrap_or(false);
+        let code = status.as_deref().and_then(http_status_code);
+        let is_deleted = matches!(code, Some(404) | Some(410));
 
         out.push(SyncItem {
             href: item.href,

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -6,13 +6,13 @@ use futures::{StreamExt, stream::FuturesOrdered};
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode, Uri, header};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{Duration, timeout};
 
 use crate::common::compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
-    detect_encodings,
+    detect_encodings, detect_request_compression_preference,
 };
 use crate::common::http::{HyperClient, build_hyper_client};
 use crate::webdav::types::{BatchItem, Depth};
@@ -20,7 +20,9 @@ use crate::webdav::types::{BatchItem, Depth};
 /// Strategy for compressing outgoing request bodies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestCompressionMode {
-    /// Negotiate automatically: attempt gzip on first use and cache the result; fall back to identity on 415/501.
+    /// Negotiate automatically: attempt gzip on first use, honor the server's advertised
+    /// `Accept-Encoding` preference on success, and cache the result; fall back to identity
+    /// on 415/501.
     Auto,
     Disabled,
     Force(ContentEncoding),
@@ -168,28 +170,47 @@ impl WebDavClient {
             RequestCompressionMode::Disabled => ContentEncoding::Identity,
             RequestCompressionMode::Force(enc) => enc,
             RequestCompressionMode::Auto => {
-                if let Ok(guard) = self.negotiated_request_compression.read() {
-                    guard.unwrap_or(AUTO_DEFAULT_ENCODING)
-                } else {
-                    AUTO_DEFAULT_ENCODING
-                }
+                // Recover from poisoning: the guarded value is a plain
+                // `Option<ContentEncoding>` that cannot be left logically
+                // inconsistent, so taking over the poisoned guard is safe.
+                self.negotiated_request_compression
+                    .read()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .unwrap_or(AUTO_DEFAULT_ENCODING)
             }
         }
     }
 
     fn set_negotiated_encoding(&self, encoding: Option<ContentEncoding>) {
-        if let Ok(mut guard) = self.negotiated_request_compression.write() {
-            *guard = encoding;
-        }
+        // Recover from poisoning: the guarded value is a plain
+        // `Option<ContentEncoding>` that cannot be left logically inconsistent,
+        // so taking over the poisoned guard is safe.
+        *self
+            .negotiated_request_compression
+            .write()
+            .unwrap_or_else(PoisonError::into_inner) = encoding;
     }
 
+    /// Probe whether the server accepts compressed request bodies.
+    ///
+    /// Sends a small gzip-compressed `PROPFIND` to the base URL. On success,
+    /// the cached encoding honors the server's advertised `Accept-Encoding`
+    /// preference (q-factors applied, `br` > `zstd` > `gzip`) when present,
+    /// and keeps gzip — proven to work by the probe — otherwise. On failure,
+    /// request compression is disabled (identity).
     async fn probe_request_compression_support(&self) {
         if !self.request_compression_mode.is_auto() {
             return;
         }
 
-        if let Ok(guard) = self.negotiated_request_compression.read()
-            && guard.is_some()
+        // Recover from poisoning: the guarded value is a plain
+        // `Option<ContentEncoding>` that cannot be left logically inconsistent,
+        // so taking over the poisoned guard is safe.
+        if self
+            .negotiated_request_compression
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_some()
         {
             return;
         }
@@ -249,7 +270,12 @@ impl WebDavClient {
 
         match result {
             Ok(Ok(resp)) if resp.status().is_success() => {
-                self.set_negotiated_encoding(Some(AUTO_DEFAULT_ENCODING));
+                // The gzip probe succeeded. Prefer the encoding the server
+                // advertises via `Accept-Encoding`; keep gzip (proven to work
+                // by the probe) when it does not advertise a preference.
+                let negotiated = detect_request_compression_preference(resp.headers())
+                    .unwrap_or(AUTO_DEFAULT_ENCODING);
+                self.set_negotiated_encoding(Some(negotiated));
             }
             _ => {
                 self.set_negotiated_encoding(Some(ContentEncoding::Identity));
@@ -276,15 +302,11 @@ impl WebDavClient {
                 | StatusCode::NOT_IMPLEMENTED
                 | StatusCode::BAD_REQUEST
         ) {
-            if let Ok(mut guard) = self.negotiated_request_compression.write() {
-                *guard = Some(ContentEncoding::Identity);
-            }
+            self.set_negotiated_encoding(Some(ContentEncoding::Identity));
             return true;
         }
 
-        if let Ok(mut guard) = self.negotiated_request_compression.write() {
-            *guard = Some(encoding);
-        }
+        self.set_negotiated_encoding(Some(encoding));
         false
     }
 
@@ -294,18 +316,19 @@ impl WebDavClient {
         headers: &mut HeaderMap,
     ) -> (Bytes, Option<ContentEncoding>) {
         if self.request_compression_mode.is_auto() {
-            let negotiated = self
+            // Recover from poisoning (here and below): the guarded value is a
+            // plain `Option<ContentEncoding>` that cannot be left logically
+            // inconsistent, so taking over the poisoned guard is safe.
+            let negotiated = *self
                 .negotiated_request_compression
                 .read()
-                .ok()
-                .and_then(|g| *g);
+                .unwrap_or_else(PoisonError::into_inner);
             if negotiated.is_none() {
                 let _probe_guard = self.request_compression_probe.lock().await;
-                let negotiated = self
+                let negotiated = *self
                     .negotiated_request_compression
                     .read()
-                    .ok()
-                    .and_then(|g| *g);
+                    .unwrap_or_else(PoisonError::into_inner);
                 if negotiated.is_none() {
                     self.probe_request_compression_support().await;
                 }
@@ -748,16 +771,40 @@ impl WebDavClient {
         out
     }
 
-    /// Check if the server supports WebDAV-Sync (RFC 6578).
+    /// Check if the server supports WebDAV-Sync (RFC 6578) on the base collection.
+    ///
+    /// Detection strategy:
+    /// 1. **`DAV:supported-report-set`** — a `PROPFIND` with `Depth: 0` asks the
+    ///    collection which reports it supports; when the multistatus body
+    ///    advertises the `sync-collection` report, support is confirmed.
+    /// 2. **Probe REPORT fallback** — when the `PROPFIND` does not confirm
+    ///    support, a minimal `sync-collection` REPORT is attempted. Only a 2xx
+    ///    status (which includes `207 Multi-Status`) counts as supported; any
+    ///    other status — including `415 Unsupported Media Type` — reports
+    ///    `false`.
     pub async fn supports_webdav_sync(&self) -> Result<bool> {
-        let options_resp = self.options("").await?;
-        if let Some(allow_header) = options_resp.headers().get("Allow")
-            && let Ok(allow_value) = allow_header.to_str()
-            && allow_value.contains("REPORT")
+        // Primary: ask the collection which reports it supports (RFC 3253 §3.1.5).
+        let supported_report_set = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop>
+    <D:supported-report-set/>
+  </D:prop>
+</D:propfind>"#;
+
+        if let Ok(response) = self.propfind("", Depth::Zero, supported_report_set).await
+            && response.status().is_success()
         {
-            return Ok(true);
+            // Pragmatic ASCII case-insensitive substring search: within a
+            // supported-report-set response, "sync-collection" can only refer
+            // to the RFC 6578 report.
+            let body = String::from_utf8_lossy(response.body());
+            if body.to_ascii_lowercase().contains("sync-collection") {
+                return Ok(true);
+            }
         }
 
+        // Fallback: attempt a minimal sync-collection REPORT; only a 2xx
+        // answer proves support.
         let test_sync = r#"<D:sync-collection xmlns:D="DAV:">
             <D:sync-token/>
             <D:sync-level>1</D:sync-level>
@@ -767,10 +814,7 @@ impl WebDavClient {
         </D:sync-collection>"#;
 
         match self.report("", Depth::One, test_sync).await {
-            Ok(response) => {
-                let status = response.status();
-                Ok(status.is_success() || status == 415)
-            }
+            Ok(response) => Ok(response.status().is_success()),
             Err(_) => Ok(false),
         }
     }

--- a/src/webdav/types.rs
+++ b/src/webdav/types.rs
@@ -23,6 +23,21 @@ pub struct BatchItem<T> {
     pub result: Result<T>,
 }
 
+/// Extract the numeric HTTP status code from a WebDAV `<D:status>` value.
+///
+/// Splits on ASCII whitespace and returns the first token that parses as a
+/// `u16` within the valid HTTP status range (`100..=599`). This handles both
+/// full status lines (`"HTTP/1.1 404 Not Found"`) and bare codes (`"404"`),
+/// while rejecting look-alikes such as `"HTTP/1.1 4040 Custom"`.
+pub(crate) fn http_status_code(status_line: &str) -> Option<u16> {
+    status_line.split_ascii_whitespace().find_map(|token| {
+        token
+            .parse::<u16>()
+            .ok()
+            .filter(|code| (100..=599).contains(code))
+    })
+}
+
 /// Common fields extracted from a WebDAV response.
 #[derive(Debug, Clone, Default)]
 pub struct DavItemCommon {

--- a/tests/unit/caldav/caldav_helpers.rs
+++ b/tests/unit/caldav/caldav_helpers.rs
@@ -562,3 +562,51 @@ fn test_caldav_namespace_calendar_color() {
     assert_eq!(calendar.color.as_deref(), Some("#0066CC"));
     assert_eq!(calendar.displayname.as_deref(), Some("Work"));
 }
+
+#[test]
+fn sync_deletion_requires_numeric_404_or_410_status() {
+    use fast_dav_rs::caldav::DavItem;
+
+    fn item_with_status(href: &str, status: &str) -> DavItem {
+        let mut item = DavItem::new();
+        item.href = href.to_string();
+        item.status = Some(status.to_string());
+        item
+    }
+
+    let items = vec![
+        item_with_status("/cal/deleted-404.ics", "HTTP/1.1 404 Not Found"),
+        item_with_status("/cal/deleted-410.ics", "HTTP/1.1 410 Gone"),
+        item_with_status("/cal/custom-4040.ics", "HTTP/1.1 4040 Custom"),
+        item_with_status("/cal/ok.ics", "HTTP/1.1 200 OK"),
+        item_with_status("/cal/bare-404.ics", "404"),
+    ];
+
+    let sync = map_sync_response(&HeaderMap::new(), items, Some("token".to_string()));
+    assert_eq!(sync.items.len(), 5);
+
+    let deleted: Vec<&str> = sync
+        .items
+        .iter()
+        .filter(|item| item.is_deleted)
+        .map(|item| item.href.as_str())
+        .collect();
+    assert_eq!(
+        deleted,
+        vec![
+            "/cal/deleted-404.ics",
+            "/cal/deleted-410.ics",
+            "/cal/bare-404.ics"
+        ]
+    );
+
+    let custom = sync
+        .items
+        .iter()
+        .find(|item| item.href == "/cal/custom-4040.ics")
+        .expect("4040 item present");
+    assert!(
+        !custom.is_deleted,
+        "\"HTTP/1.1 4040 Custom\" must not be treated as a 404 deletion"
+    );
+}

--- a/tests/unit/carddav/carddav_helpers.rs
+++ b/tests/unit/carddav/carddav_helpers.rs
@@ -545,3 +545,51 @@ fn test_carddav_namespace_addressbook_color() {
     assert_eq!(book.color.as_deref(), Some("#0066CC"));
     assert_eq!(book.displayname.as_deref(), Some("Work"));
 }
+
+#[test]
+fn sync_deletion_requires_numeric_404_or_410_status() {
+    use fast_dav_rs::carddav::DavItem;
+
+    fn item_with_status(href: &str, status: &str) -> DavItem {
+        let mut item = DavItem::new();
+        item.href = href.to_string();
+        item.status = Some(status.to_string());
+        item
+    }
+
+    let items = vec![
+        item_with_status("/card/deleted-404.vcf", "HTTP/1.1 404 Not Found"),
+        item_with_status("/card/deleted-410.vcf", "HTTP/1.1 410 Gone"),
+        item_with_status("/card/custom-4040.vcf", "HTTP/1.1 4040 Custom"),
+        item_with_status("/card/ok.vcf", "HTTP/1.1 200 OK"),
+        item_with_status("/card/bare-404.vcf", "404"),
+    ];
+
+    let sync = map_sync_response(&HeaderMap::new(), items, Some("token".to_string()));
+    assert_eq!(sync.items.len(), 5);
+
+    let deleted: Vec<&str> = sync
+        .items
+        .iter()
+        .filter(|item| item.is_deleted)
+        .map(|item| item.href.as_str())
+        .collect();
+    assert_eq!(
+        deleted,
+        vec![
+            "/card/deleted-404.vcf",
+            "/card/deleted-410.vcf",
+            "/card/bare-404.vcf"
+        ]
+    );
+
+    let custom = sync
+        .items
+        .iter()
+        .find(|item| item.href == "/card/custom-4040.vcf")
+        .expect("4040 item present");
+    assert!(
+        !custom.is_deleted,
+        "\"HTTP/1.1 4040 Custom\" must not be treated as a 404 deletion"
+    );
+}


### PR DESCRIPTION
… lock poisoning and probe negotiation

- supports_webdav_sync: check DAV:supported-report-set for sync-collection; 415 no longer treated as success
- parse numeric HTTP status codes for sync deletion detection (404/410) instead of substring matching
- recover RwLock poisoning explicitly instead of silent fallbacks
- compression probe honors the server's Accept-Encoding preference via detect_request_compression_preference