### PR TITLE
fix(security): escape and validate calendar query inputs, harden cred…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "quick-xml",
  "tokio",
  "tokio-util",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio-util = "0.7"
 async-compression = { version = "0.4", features = ["tokio", "brotli", "gzip", "zstd"] }
 hyper-util = { version = "0.1", features = ["client", "http1", "http2", "tokio"] }
 http-body-util = "0.1"
+zeroize = "1"
 
 [dev-dependencies]
 tokio = { version = "1.50.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ features, and major releases introduce breaking changes when needed.
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
+- [Security](#security)
 - [Usage Examples](#usage-examples)
 - [Streaming & Sync](#streaming--sync)
 - [Batch Operations](#batch-operations)
@@ -182,6 +183,15 @@ so you can override the default timeout for specific requests.
 
 `propfind_many` and `report_many` accept a `max_concurrency` parameter to bound the number of in-flight
 requests while preserving input order in the result list.
+
+## Security
+
+Basic credentials are sent as an `Authorization: Basic` header on every request. Base64 is an
+encoding, not encryption: over plain `http://` your username and password travel effectively in
+cleartext and can be read by anyone on the network path. The connector intentionally accepts both
+`http://` and `https://` (plain HTTP is convenient for isolated test environments such as the
+bundled Docker setup), so the library does not reject `http://` at runtime — **always use
+`https://` outside isolated test environments**.
 
 ## Usage Examples
 

--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -11,8 +11,8 @@ use crate::caldav::types::{
 };
 use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
-use crate::webdav::xml::{validate_component_name, validate_utc_datetime};
 use crate::webdav::types::http_status_code;
+use crate::webdav::xml::{validate_component_name, validate_utc_datetime};
 
 pub use crate::webdav::client::RequestCompressionMode;
 

--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -11,6 +11,7 @@ use crate::caldav::types::{
 };
 use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
+use crate::webdav::xml::{validate_component_name, validate_utc_datetime};
 
 pub use crate::webdav::client::RequestCompressionMode;
 
@@ -35,6 +36,14 @@ impl CalDavClient {
     /// Create a new client from a **base URL** (collection/home-set) and optional **Basic** credentials.
     ///
     /// The base may be `https://` **or** `http://` (both are supported by the connector).
+    ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on **every**
+    /// request. Base64 is an encoding, not encryption: over plain `http://` the
+    /// credentials travel effectively in cleartext and can be read by anyone on the
+    /// network path. Always use `https://` outside isolated test environments
+    /// (e.g. a local Docker test server).
     ///
     /// # Arguments
     ///
@@ -431,6 +440,20 @@ impl CalDavClient {
     ///
     /// `component` should be `VEVENT`, `VTODO`, … while `start`/`end` are ISO-8601
     /// timestamps in the format required by CalDAV (e.g. `20240101T000000Z`).
+    ///
+    /// Inputs are validated before any request is sent, and additionally
+    /// XML-escaped when the request body is built (defense in depth).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error **before any network I/O** if:
+    /// - `component` is empty or contains characters outside ASCII
+    ///   alphanumerics and `-` (e.g. `VEVENT` and `X-CUSTOM` are valid)
+    /// - `start` or `end` is provided but is not a structurally valid
+    ///   iCalendar UTC date-time (`YYYYMMDDTHHMMSSZ`)
+    ///
+    /// Also returns an error if the REPORT request fails or the server
+    /// responds with a non-success status.
     pub async fn calendar_query_timerange(
         &self,
         calendar_path: &str,
@@ -439,6 +462,15 @@ impl CalDavClient {
         end: Option<&str>,
         include_data: bool,
     ) -> Result<Vec<CalendarObject>> {
+        validate_component_name(component)
+            .map_err(|e| anyhow!("invalid calendar-query component: {e}"))?;
+        if let Some(s) = start {
+            validate_utc_datetime(s).map_err(|e| anyhow!("invalid calendar-query start: {e}"))?;
+        }
+        if let Some(e) = end {
+            validate_utc_datetime(e).map_err(|e| anyhow!("invalid calendar-query end: {e}"))?;
+        }
+
         let xml = build_calendar_query_body(component, start, end, include_data);
 
         let resp = self.report(calendar_path, Depth::One, &xml).await?;
@@ -617,15 +649,15 @@ pub fn build_calendar_query_body(
         "<C:filter>\
            <C:comp-filter name=\"VCALENDAR\">\
              <C:comp-filter name=\"{}\">",
-        component
+        escape_xml(component)
     );
     if start.is_some() || end.is_some() {
         filter.push_str("<C:time-range");
         if let Some(s) = start {
-            filter.push_str(&format!(" start=\"{}\"", s));
+            filter.push_str(&format!(" start=\"{}\"", escape_xml(s)));
         }
         if let Some(e) = end {
-            filter.push_str(&format!(" end=\"{}\"", e));
+            filter.push_str(&format!(" end=\"{}\"", escape_xml(e)));
         }
         filter.push_str("/>");
     }

--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -36,6 +36,14 @@ impl CardDavClient {
     ///
     /// The base may be `https://` **or** `http://` (both are supported by the connector).
     ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on **every**
+    /// request. Base64 is an encoding, not encryption: over plain `http://` the
+    /// credentials travel effectively in cleartext and can be read by anyone on the
+    /// network path. Always use `https://` outside isolated test environments
+    /// (e.g. a local Docker test server).
+    ///
     /// # Arguments
     ///
     /// * `base_url` - The base URL for the CardDAV server (must be a valid URI)

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -9,6 +9,7 @@ use hyper::{HeaderMap, Method, Request, Response, StatusCode, Uri, header};
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{Duration, timeout};
+use zeroize::Zeroize;
 
 use crate::common::compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
@@ -44,6 +45,14 @@ const PROBE_BODY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 pub struct WebDavClient {
     base: Uri,
     client: HyperClient,
+    /// Pre-built `Authorization: Basic …` value attached to every request, if
+    /// credentials were provided.
+    ///
+    /// Residual limitation: the intermediate credential strings are zeroized in
+    /// [`WebDavClient::new`], but this `HeaderValue` necessarily keeps a Base64
+    /// copy of the credentials in memory for the whole lifetime of the client
+    /// (and its clones) and is **not** zeroized on drop. This is an accepted
+    /// trade-off so the header can be attached cheaply to each request.
     auth_header: Option<header::HeaderValue>,
     default_timeout: Duration,
     request_compression_mode: RequestCompressionMode,
@@ -55,14 +64,27 @@ impl WebDavClient {
     /// Create a new client from a **base URL** (collection/home-set) and optional **Basic** credentials.
     ///
     /// The base may be `https://` **or** `http://` (both are supported by the connector).
+    ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on **every**
+    /// request. Base64 is an encoding, not encryption: over plain `http://` the
+    /// credentials travel effectively in cleartext and can be read by anyone on the
+    /// network path. Always use `https://` outside isolated test environments
+    /// (e.g. a local Docker test server).
     pub fn new(base_url: &str, basic_user: Option<&str>, basic_pass: Option<&str>) -> Result<Self> {
         let client = build_hyper_client()?;
 
         let base: Uri = base_url.parse()?;
         let auth_header = if let (Some(u), Some(p)) = (basic_user, basic_pass) {
-            let token = format!("{}:{}", u, p);
-            let val = format!("Basic {}", B64.encode(token));
-            Some(header::HeaderValue::from_str(&val)?)
+            // Build the header value, then zeroize the intermediate strings so
+            // plaintext credentials do not linger in freed heap memory.
+            let mut token = format!("{}:{}", u, p);
+            let mut val = format!("Basic {}", B64.encode(&token));
+            let header_value = header::HeaderValue::from_str(&val);
+            token.zeroize();
+            val.zeroize();
+            Some(header_value?)
         } else {
             None
         };

--- a/src/webdav/xml.rs
+++ b/src/webdav/xml.rs
@@ -1,3 +1,5 @@
+use anyhow::{Result, anyhow};
+
 pub fn escape_xml(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for ch in input.chars() {
@@ -11,6 +13,60 @@ pub fn escape_xml(input: &str) -> String {
         }
     }
     out
+}
+
+/// Validate an iCalendar component name (e.g. `VEVENT`, `VTODO`, `X-CUSTOM`).
+///
+/// Accepts non-empty names made exclusively of ASCII alphanumeric characters
+/// or `-`, matching the iCalendar component-name grammar. Anything else
+/// (whitespace, quotes, XML metacharacters, non-ASCII, …) is rejected so
+/// untrusted values cannot alter the structure of generated request XML.
+///
+/// # Errors
+///
+/// Returns an error when `name` is empty or contains a character outside
+/// `[A-Za-z0-9-]`.
+pub(crate) fn validate_component_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(anyhow!("component name must not be empty"));
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))
+    {
+        return Err(anyhow!(
+            "component name {name:?} contains invalid character {bad:?}: \
+             only ASCII letters, digits and '-' are allowed (e.g. VEVENT, X-CUSTOM)"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate the structure of an iCalendar UTC date-time (RFC 5545 `DATE-TIME`
+/// form 2), e.g. `20240101T000000Z`.
+///
+/// This is a purely structural check — exactly 8 ASCII digits, a literal `T`,
+/// 6 ASCII digits, and a literal `Z` — used to keep untrusted values out of
+/// generated request XML. It deliberately does not validate calendar
+/// semantics (month/day ranges, leap years, …).
+///
+/// # Errors
+///
+/// Returns an error when `value` does not match `YYYYMMDDTHHMMSSZ`.
+pub(crate) fn validate_utc_datetime(value: &str) -> Result<()> {
+    let bytes = value.as_bytes();
+    let structurally_valid = bytes.len() == 16
+        && bytes[..8].iter().all(u8::is_ascii_digit)
+        && bytes[8] == b'T'
+        && bytes[9..15].iter().all(u8::is_ascii_digit)
+        && bytes[15] == b'Z';
+    if !structurally_valid {
+        return Err(anyhow!(
+            "invalid UTC date-time {value:?}: expected iCalendar format \
+             YYYYMMDDTHHMMSSZ (e.g. 20240101T000000Z)"
+        ));
+    }
+    Ok(())
 }
 
 pub fn build_sync_collection_body(

--- a/tests/unit/caldav/caldav_helpers.rs
+++ b/tests/unit/caldav/caldav_helpers.rs
@@ -19,6 +19,54 @@ fn builds_calendar_query_with_timerange() {
 }
 
 #[test]
+fn calendar_query_body_escapes_injection_attempts() {
+    let body = build_calendar_query_body(
+        "VEVENT\"><inject:evil/><!--",
+        Some("2024\"><x/>&"),
+        Some("20240201T000000Z'"),
+        false,
+    );
+
+    // Raw injection artifacts must not survive escaping.
+    assert!(!body.contains("<inject:evil/>"));
+    assert!(!body.contains("<x/>"));
+    assert!(!body.contains("<!--"));
+
+    // Special characters are entity-encoded instead.
+    assert!(body.contains("name=\"VEVENT&quot;&gt;&lt;inject:evil/&gt;&lt;!--\""));
+    assert!(body.contains("start=\"2024&quot;&gt;&lt;x/&gt;&amp;\""));
+    assert!(body.contains("end=\"20240201T000000Z&apos;\""));
+}
+
+#[test]
+fn calendar_query_body_valid_inputs_pass_through_unchanged() {
+    // Valid component names and UTC date-times contain no XML metacharacters,
+    // so escaping must leave them byte-for-byte untouched.
+    let body = build_calendar_query_body(
+        "X-CUSTOM",
+        Some("20240101T000000Z"),
+        Some("20241231T235959Z"),
+        false,
+    );
+    assert!(body.contains("name=\"X-CUSTOM\""));
+    assert!(body.contains("start=\"20240101T000000Z\""));
+    assert!(body.contains("end=\"20241231T235959Z\""));
+    assert!(!body.contains("&quot;") && !body.contains("&lt;") && !body.contains("&amp;"));
+}
+
+#[test]
+fn calendar_multiget_body_escapes_xml_metacharacters_in_hrefs() {
+    let body =
+        build_calendar_multiget_body(vec![r#"/cal/a.ics"/><D:href>injected</D:href><!--"#], false)
+            .expect("hrefs present");
+
+    assert!(!body.contains("<D:href>injected</D:href>"));
+    assert!(body.contains(
+        "<D:href>/cal/a.ics&quot;/&gt;&lt;D:href&gt;injected&lt;/D:href&gt;&lt;!--</D:href>"
+    ));
+}
+
+#[test]
 fn builds_calendar_multiget_and_escapes() {
     let body = build_calendar_multiget_body(
         vec![

--- a/tests/unit/caldav/client_tests.rs
+++ b/tests/unit/caldav/client_tests.rs
@@ -296,3 +296,72 @@ fn test_map_sync_response() {
     );
     assert!(response.items[1].is_deleted); // Should be marked as deleted
 }
+
+#[tokio::test]
+async fn test_calendar_query_timerange_rejects_malicious_component() {
+    let client = CalDavClient::new("https://example.com/dav/", Some("user"), Some("pass"))
+        .expect("Failed to create client");
+
+    let err = client
+        .calendar_query_timerange("calendar/", "VEVENT\"><evil/>", None, None, false)
+        .await
+        .expect_err("component with XML metacharacters must be rejected before any request");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid calendar-query component"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_calendar_query_timerange_rejects_empty_component() {
+    let client =
+        CalDavClient::new("https://example.com/dav/", None, None).expect("Failed to create client");
+
+    let err = client
+        .calendar_query_timerange("calendar/", "", None, None, false)
+        .await
+        .expect_err("empty component must be rejected before any request");
+    assert!(err.to_string().contains("invalid calendar-query component"));
+}
+
+#[tokio::test]
+async fn test_calendar_query_timerange_rejects_malformed_start() {
+    let client =
+        CalDavClient::new("https://example.com/dav/", None, None).expect("Failed to create client");
+
+    let err = client
+        .calendar_query_timerange(
+            "calendar/",
+            "VEVENT",
+            Some("2024-01-01T00:00:00Z"),
+            None,
+            false,
+        )
+        .await
+        .expect_err("malformed start must be rejected before any request");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid calendar-query start"),
+        "unexpected error: {msg}"
+    );
+    assert!(msg.contains("YYYYMMDDTHHMMSSZ"), "unexpected error: {msg}");
+}
+
+#[tokio::test]
+async fn test_calendar_query_timerange_rejects_malformed_end() {
+    let client =
+        CalDavClient::new("https://example.com/dav/", None, None).expect("Failed to create client");
+
+    let err = client
+        .calendar_query_timerange(
+            "calendar/",
+            "VEVENT",
+            Some("20240101T000000Z"),
+            Some("20240101T000000Z\"><inject/>"),
+            false,
+        )
+        .await
+        .expect_err("malformed end must be rejected before any request");
+    assert!(err.to_string().contains("invalid calendar-query end"));
+}


### PR DESCRIPTION
…ential handling

- escape component/start/end in calendar-query XML (injection fix) and multiget hrefs
- validate component names and iCalendar UTC datetimes at the API boundary
- zeroize intermediate credential strings; document HeaderValue limitation
- document Basic-over-HTTP cleartext risk on constructors and README