### PR TITLE
fix(streaming): harden multistatus parsing truncated responses

### DIFF
--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -8,6 +8,7 @@ pub use client::{
 };
 pub use streaming::{
     parse_multistatus_bytes, parse_multistatus_bytes_visit, parse_multistatus_stream,
-    parse_multistatus_stream_visit,
+    parse_multistatus_stream_visit, parse_multistatus_stream_visit_with_timeout,
+    parse_multistatus_stream_with_timeout,
 };
 pub use types::{BatchItem, CalendarInfo, CalendarObject, DavItem, Depth, SyncItem, SyncResponse};

--- a/src/caldav/streaming.rs
+++ b/src/caldav/streaming.rs
@@ -9,9 +9,18 @@ use quick_xml::escape::unescape;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Decoder, Reader, XmlVersion};
 use std::io::{BufRead, Cursor};
+use std::time::Duration;
 use tokio::io::AsyncBufRead;
 use tokio::io::BufReader;
 use tokio_util::io::StreamReader;
+
+/// Default **idle** timeout for streaming multistatus reads.
+///
+/// This bounds the time the parser waits for the next XML event to become available,
+/// i.e. the maximum period of inactivity between two reads making progress. It is not
+/// a cap on the total parse duration: arbitrarily large responses are fine as long as
+/// data keeps flowing.
+pub const STREAM_READ_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElementName {
@@ -144,11 +153,17 @@ impl<C: ItemConsumer> MultistatusParser<C> {
         }
     }
 
-    fn finish(self) -> ParseResult<C> {
-        ParseResult {
+    fn finish(self) -> Result<ParseResult<C>> {
+        if let Some(unclosed) = self.stack.last() {
+            return Err(anyhow!(
+                "XML structure error: unexpected end of input with unclosed element {unclosed:?}"
+            ));
+        }
+
+        Ok(ParseResult {
             items: self.sink,
             sync_token: self.sync_token,
-        }
+        })
     }
 
     pub fn path_ends_with(&self, needle: &[ElementName]) -> bool {
@@ -184,7 +199,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     ElementName::Comp,
                 ]) =>
             {
-                for attr in event.attributes().with_checks(false) {
+                for attr in event.attributes().with_checks(true) {
                     let attr = attr?;
                     let key = String::from_utf8_lossy(attr.key.as_ref()).to_ascii_lowercase();
                     if key == "name" {
@@ -211,8 +226,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
     }
 
     fn on_end(&mut self, name: &[u8]) -> Result<()> {
-        self.common.on_end(name);
-        let element = element_from_bytes(name);
+        self.common.on_end(name)?;
         if let Some(popped) = self.stack.pop()
             && popped == ElementName::Response
         {
@@ -220,17 +234,6 @@ impl<C: ItemConsumer> MultistatusParser<C> {
             self.current.apply_common(common);
             let finished = std::mem::take(&mut self.current);
             self.sink.consume(finished)?;
-            // Ignore mismatches silently; the XML is assumed well-formed.
-        }
-        if element == ElementName::Response && !self.stack.is_empty() {
-            // Make sure we consume any residual state if nested (should not happen).
-            while let Some(last) = self.stack.last() {
-                if *last == ElementName::Response {
-                    self.stack.pop();
-                } else {
-                    break;
-                }
-            }
         }
         Ok(())
     }
@@ -318,14 +321,16 @@ async fn parse_multistatus_stream_with<C>(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
     sink: C,
+    idle_timeout: Duration,
 ) -> Result<ParseResult<C>>
 where
     C: ItemConsumer + Send,
 {
     use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZstdDecoder};
 
+    // Non-data frames (e.g. HTTP/2 trailers) are intentionally skipped.
     let stream = BodyStream::new(resp_body)
-        .map_ok(|frame| frame.into_data().unwrap_or_default())
+        .try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok())))
         .map_err(std::io::Error::other);
     let mut reader: Box<dyn AsyncBufRead + Unpin + Send> =
         Box::new(BufReader::new(StreamReader::new(stream)));
@@ -345,7 +350,12 @@ where
     let mut parser = MultistatusParser::new(sink);
 
     loop {
-        match xml.read_event_into_async(&mut buf).await {
+        let event = tokio::time::timeout(idle_timeout, xml.read_event_into_async(&mut buf))
+            .await
+            .map_err(|_| {
+                anyhow!("streaming read timed out after {idle_timeout:?} of inactivity")
+            })?;
+        match event {
             Ok(Event::Start(e)) => parser.on_start(&e, xml.decoder())?,
             Ok(Event::Empty(e)) => {
                 parser.on_start(&e, xml.decoder())?;
@@ -367,7 +377,7 @@ where
         buf.clear();
     }
 
-    Ok(parser.finish())
+    parser.finish()
 }
 
 fn parse_multistatus_bytes_with<R, C>(reader: R, sink: C) -> Result<ParseResult<C>>
@@ -404,7 +414,7 @@ where
         buf.clear();
     }
 
-    Ok(parser.finish())
+    parser.finish()
 }
 
 /// Parse a WebDAV `207 Multi-Status` XML body in **streaming mode**, with optional
@@ -412,14 +422,34 @@ where
 ///
 /// This function avoids loading the entire response into memory, making it suitable
 /// for very large CalDAV/WebDAV collections.
+///
+/// Reads are bounded by the default idle timeout ([`STREAM_READ_IDLE_TIMEOUT`]); use
+/// [`parse_multistatus_stream_with_timeout`] to customize it.
 pub async fn parse_multistatus_stream(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
 ) -> Result<ParseResult<Vec<DavItem>>> {
-    parse_multistatus_stream_with(resp_body, encodings, Vec::<DavItem>::new()).await
+    parse_multistatus_stream_with_timeout(resp_body, encodings, STREAM_READ_IDLE_TIMEOUT).await
+}
+
+/// Variant of [`parse_multistatus_stream`] with a caller-provided **idle** timeout.
+///
+/// `idle_timeout` is the maximum time allowed between two reads making progress
+/// (i.e. waiting for the next XML event to arrive from the network). It is **not**
+/// a cap on the total parse duration, so huge-but-flowing responses are unaffected.
+/// When the timeout elapses, an error is returned and parsing stops.
+pub async fn parse_multistatus_stream_with_timeout(
+    resp_body: Incoming,
+    encodings: &[ContentEncoding],
+    idle_timeout: Duration,
+) -> Result<ParseResult<Vec<DavItem>>> {
+    parse_multistatus_stream_with(resp_body, encodings, Vec::<DavItem>::new(), idle_timeout).await
 }
 
 /// Stream parse a WebDAV `207 Multi-Status` response and invoke a callback for each item.
+///
+/// Reads are bounded by the default idle timeout ([`STREAM_READ_IDLE_TIMEOUT`]); use
+/// [`parse_multistatus_stream_visit_with_timeout`] to customize it.
 pub async fn parse_multistatus_stream_visit<F>(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
@@ -428,7 +458,31 @@ pub async fn parse_multistatus_stream_visit<F>(
 where
     F: FnMut(DavItem) -> Result<()> + Send,
 {
-    let result = parse_multistatus_stream_with(resp_body, encodings, on_item).await?;
+    parse_multistatus_stream_visit_with_timeout(
+        resp_body,
+        encodings,
+        STREAM_READ_IDLE_TIMEOUT,
+        on_item,
+    )
+    .await
+}
+
+/// Variant of [`parse_multistatus_stream_visit`] with a caller-provided **idle** timeout.
+///
+/// `idle_timeout` is the maximum time allowed between two reads making progress
+/// (i.e. waiting for the next XML event to arrive from the network). It is **not**
+/// a cap on the total parse duration, so huge-but-flowing responses are unaffected.
+/// When the timeout elapses, an error is returned and parsing stops.
+pub async fn parse_multistatus_stream_visit_with_timeout<F>(
+    resp_body: Incoming,
+    encodings: &[ContentEncoding],
+    idle_timeout: Duration,
+    on_item: F,
+) -> Result<Option<String>>
+where
+    F: FnMut(DavItem) -> Result<()> + Send,
+{
+    let result = parse_multistatus_stream_with(resp_body, encodings, on_item, idle_timeout).await?;
     Ok(result.sync_token)
 }
 

--- a/src/carddav/mod.rs
+++ b/src/carddav/mod.rs
@@ -12,7 +12,8 @@ pub use client::{
 };
 pub use streaming::{
     parse_multistatus_bytes, parse_multistatus_bytes_visit, parse_multistatus_stream,
-    parse_multistatus_stream_visit,
+    parse_multistatus_stream_visit, parse_multistatus_stream_visit_with_timeout,
+    parse_multistatus_stream_with_timeout,
 };
 pub use types::{
     AddressBookInfo, AddressObject, BatchItem, DavItem, Depth, SyncItem, SyncResponse,

--- a/src/carddav/streaming.rs
+++ b/src/carddav/streaming.rs
@@ -9,9 +9,18 @@ use quick_xml::escape::unescape;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Decoder, Reader, XmlVersion};
 use std::io::{BufRead, Cursor};
+use std::time::Duration;
 use tokio::io::AsyncBufRead;
 use tokio::io::BufReader;
 use tokio_util::io::StreamReader;
+
+/// Default **idle** timeout for streaming multistatus reads.
+///
+/// This bounds the time the parser waits for the next XML event to become available,
+/// i.e. the maximum period of inactivity between two reads making progress. It is not
+/// a cap on the total parse duration: arbitrarily large responses are fine as long as
+/// data keeps flowing.
+pub const STREAM_READ_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElementName {
@@ -141,11 +150,17 @@ impl<C: ItemConsumer> MultistatusParser<C> {
         }
     }
 
-    fn finish(self) -> ParseResult<C> {
-        ParseResult {
+    fn finish(self) -> Result<ParseResult<C>> {
+        if let Some(unclosed) = self.stack.last() {
+            return Err(anyhow!(
+                "XML structure error: unexpected end of input with unclosed element {unclosed:?}"
+            ));
+        }
+
+        Ok(ParseResult {
             items: self.sink,
             sync_token: self.sync_token,
-        }
+        })
     }
 
     pub fn path_ends_with(&self, needle: &[ElementName]) -> bool {
@@ -183,7 +198,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
             {
                 let mut content_type = None;
                 let mut version = None;
-                for attr in event.attributes().with_checks(false) {
+                for attr in event.attributes().with_checks(true) {
                     let attr = attr?;
                     let key = String::from_utf8_lossy(attr.key.as_ref()).to_ascii_lowercase();
                     if key == "content-type" {
@@ -227,8 +242,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
     }
 
     fn on_end(&mut self, name: &[u8]) -> Result<()> {
-        self.common.on_end(name);
-        let element = element_from_bytes(name);
+        self.common.on_end(name)?;
         if let Some(popped) = self.stack.pop()
             && popped == ElementName::Response
         {
@@ -236,17 +250,6 @@ impl<C: ItemConsumer> MultistatusParser<C> {
             self.current.apply_common(common);
             let finished = std::mem::take(&mut self.current);
             self.sink.consume(finished)?;
-            // Ignore mismatches silently; the XML is assumed well-formed.
-        }
-        if element == ElementName::Response && !self.stack.is_empty() {
-            // Make sure we consume any residual state if nested (should not happen).
-            while let Some(last) = self.stack.last() {
-                if *last == ElementName::Response {
-                    self.stack.pop();
-                } else {
-                    break;
-                }
-            }
         }
         Ok(())
     }
@@ -319,14 +322,16 @@ async fn parse_multistatus_stream_with<C>(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
     sink: C,
+    idle_timeout: Duration,
 ) -> Result<ParseResult<C>>
 where
     C: ItemConsumer + Send,
 {
     use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZstdDecoder};
 
+    // Non-data frames (e.g. HTTP/2 trailers) are intentionally skipped.
     let stream = BodyStream::new(resp_body)
-        .map_ok(|frame| frame.into_data().unwrap_or_default())
+        .try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok())))
         .map_err(std::io::Error::other);
     let mut reader: Box<dyn AsyncBufRead + Unpin + Send> =
         Box::new(BufReader::new(StreamReader::new(stream)));
@@ -346,7 +351,12 @@ where
     let mut parser = MultistatusParser::new(sink);
 
     loop {
-        match xml.read_event_into_async(&mut buf).await {
+        let event = tokio::time::timeout(idle_timeout, xml.read_event_into_async(&mut buf))
+            .await
+            .map_err(|_| {
+                anyhow!("streaming read timed out after {idle_timeout:?} of inactivity")
+            })?;
+        match event {
             Ok(Event::Start(e)) => parser.on_start(&e, xml.decoder())?,
             Ok(Event::Empty(e)) => {
                 parser.on_start(&e, xml.decoder())?;
@@ -368,7 +378,7 @@ where
         buf.clear();
     }
 
-    Ok(parser.finish())
+    parser.finish()
 }
 
 fn parse_multistatus_bytes_with<R, C>(reader: R, sink: C) -> Result<ParseResult<C>>
@@ -405,7 +415,7 @@ where
         buf.clear();
     }
 
-    Ok(parser.finish())
+    parser.finish()
 }
 
 /// Parse a WebDAV `207 Multi-Status` XML body in **streaming mode**, with optional
@@ -413,14 +423,34 @@ where
 ///
 /// This function avoids loading the entire response into memory, making it suitable
 /// for very large CardDAV/WebDAV collections.
+///
+/// Reads are bounded by the default idle timeout ([`STREAM_READ_IDLE_TIMEOUT`]); use
+/// [`parse_multistatus_stream_with_timeout`] to customize it.
 pub async fn parse_multistatus_stream(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
 ) -> Result<ParseResult<Vec<DavItem>>> {
-    parse_multistatus_stream_with(resp_body, encodings, Vec::<DavItem>::new()).await
+    parse_multistatus_stream_with_timeout(resp_body, encodings, STREAM_READ_IDLE_TIMEOUT).await
+}
+
+/// Variant of [`parse_multistatus_stream`] with a caller-provided **idle** timeout.
+///
+/// `idle_timeout` is the maximum time allowed between two reads making progress
+/// (i.e. waiting for the next XML event to arrive from the network). It is **not**
+/// a cap on the total parse duration, so huge-but-flowing responses are unaffected.
+/// When the timeout elapses, an error is returned and parsing stops.
+pub async fn parse_multistatus_stream_with_timeout(
+    resp_body: Incoming,
+    encodings: &[ContentEncoding],
+    idle_timeout: Duration,
+) -> Result<ParseResult<Vec<DavItem>>> {
+    parse_multistatus_stream_with(resp_body, encodings, Vec::<DavItem>::new(), idle_timeout).await
 }
 
 /// Stream parse a WebDAV `207 Multi-Status` response and invoke a callback for each item.
+///
+/// Reads are bounded by the default idle timeout ([`STREAM_READ_IDLE_TIMEOUT`]); use
+/// [`parse_multistatus_stream_visit_with_timeout`] to customize it.
 pub async fn parse_multistatus_stream_visit<F>(
     resp_body: Incoming,
     encodings: &[ContentEncoding],
@@ -429,7 +459,31 @@ pub async fn parse_multistatus_stream_visit<F>(
 where
     F: FnMut(DavItem) -> Result<()> + Send,
 {
-    let result = parse_multistatus_stream_with(resp_body, encodings, on_item).await?;
+    parse_multistatus_stream_visit_with_timeout(
+        resp_body,
+        encodings,
+        STREAM_READ_IDLE_TIMEOUT,
+        on_item,
+    )
+    .await
+}
+
+/// Variant of [`parse_multistatus_stream_visit`] with a caller-provided **idle** timeout.
+///
+/// `idle_timeout` is the maximum time allowed between two reads making progress
+/// (i.e. waiting for the next XML event to arrive from the network). It is **not**
+/// a cap on the total parse duration, so huge-but-flowing responses are unaffected.
+/// When the timeout elapses, an error is returned and parsing stops.
+pub async fn parse_multistatus_stream_visit_with_timeout<F>(
+    resp_body: Incoming,
+    encodings: &[ContentEncoding],
+    idle_timeout: Duration,
+    on_item: F,
+) -> Result<Option<String>>
+where
+    F: FnMut(DavItem) -> Result<()> + Send,
+{
+    let result = parse_multistatus_stream_with(resp_body, encodings, on_item, idle_timeout).await?;
     Ok(result.sync_token)
 }
 

--- a/src/common/compression.rs
+++ b/src/common/compression.rs
@@ -181,8 +181,9 @@ pub fn detect_encoding(headers: &HeaderMap) -> ContentEncoding {
 /// This function takes an aggregated response body and decompresses it according
 /// to the specified encoding.
 pub async fn decompress_body(body: Incoming, encodings: &[ContentEncoding]) -> Result<Bytes> {
+    // Non-data frames (e.g. HTTP/2 trailers) are intentionally skipped.
     let stream = BodyStream::new(body)
-        .map_ok(|frame| frame.into_data().unwrap_or_default())
+        .try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok())))
         .map_err(std::io::Error::other);
     let reader = StreamReader::new(stream);
     let reader = BufReader::new(reader);
@@ -212,8 +213,9 @@ pub fn decompress_stream(
     body: Incoming,
     encodings: &[ContentEncoding],
 ) -> Result<Box<dyn AsyncBufRead + Unpin + Send>> {
+    // Non-data frames (e.g. HTTP/2 trailers) are intentionally skipped.
     let stream = BodyStream::new(body)
-        .map_ok(|frame| frame.into_data().unwrap_or_default())
+        .try_filter_map(|frame| std::future::ready(Ok(frame.into_data().ok())))
         .map_err(std::io::Error::other);
     let reader: Box<dyn AsyncBufRead + Unpin + Send> =
         Box::new(BufReader::new(StreamReader::new(stream)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,8 @@ pub mod webdav;
 // Backwards-compatible re-exports
 pub use caldav::streaming::{
     parse_multistatus_bytes, parse_multistatus_bytes_visit, parse_multistatus_stream,
-    parse_multistatus_stream_visit,
+    parse_multistatus_stream_visit, parse_multistatus_stream_visit_with_timeout,
+    parse_multistatus_stream_with_timeout,
 };
 pub use caldav::{
     BatchItem, CalDavClient, CalendarInfo, CalendarObject, DavItem, Depth, SyncItem, SyncResponse,

--- a/src/webdav/streaming.rs
+++ b/src/webdav/streaming.rs
@@ -1,4 +1,5 @@
 use crate::webdav::types::DavItemCommon;
+use anyhow::{Result, anyhow};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommonElement {
@@ -101,21 +102,18 @@ impl CommonParser {
         }
     }
 
-    pub(crate) fn on_end(&mut self, raw: &[u8]) {
+    pub(crate) fn on_end(&mut self, raw: &[u8]) -> Result<()> {
         let element = common_element_from_bytes(raw);
-        if let Some(popped) = self.stack.pop()
-            && popped != element
-        {
-            // Ignore mismatches silently; the XML is assumed well-formed.
-        }
-        if element == CommonElement::Response && !self.stack.is_empty() {
-            while let Some(last) = self.stack.last() {
-                if *last == CommonElement::Response {
-                    self.stack.pop();
-                } else {
-                    break;
-                }
-            }
+        match self.stack.pop() {
+            Some(popped) if popped == element => Ok(()),
+            Some(popped) => Err(anyhow!(
+                "XML structure error: closing tag </{}> does not match the last opened element (expected {popped:?}, found {element:?})",
+                String::from_utf8_lossy(raw)
+            )),
+            None => Err(anyhow!(
+                "XML structure error: closing tag </{}> without a matching opening tag",
+                String::from_utf8_lossy(raw)
+            )),
         }
     }
 

--- a/tests/unit/caldav/parser_edge_cases.rs
+++ b/tests/unit/caldav/parser_edge_cases.rs
@@ -44,7 +44,6 @@ fn test_parse_multistatus_performance() {
 
 #[test]
 fn test_parse_multistatus_malformed_xml() {
-    // Test with malformed XML
     let malformed_xml = r#"<?xml version="1.0" encoding="utf-8"?>
 <D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
   <D:response>
@@ -56,10 +55,62 @@ fn test_parse_multistatus_malformed_xml() {
       <!-- Missing closing tags -->
 "#;
 
-    let result = parse_multistatus_bytes(malformed_xml.as_bytes());
-    // Depending on the parser implementation, this might either error or partially parse
-    // The important thing is that it doesn't panic or cause undefined behavior
-    println!("Malformed XML parsing result: {:?}", result.is_ok());
+    let err = parse_multistatus_bytes(malformed_xml.as_bytes())
+        .expect_err("truncated XML must be rejected");
+    assert!(
+        err.to_string().contains("unclosed element"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_parse_multistatus_duplicate_attribute_errors() {
+    // quick-xml attribute checks are enabled: a duplicated attribute coming from a
+    // buggy or malicious server must be a parse error, not silently tolerated.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:response>
+    <D:href>/dav/user01/personal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT" name="VTODO"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"#;
+
+    let result = parse_multistatus_bytes(xml.as_bytes());
+    assert!(
+        result.is_err(),
+        "duplicated attribute should be rejected as a parse error"
+    );
+}
+
+#[test]
+fn test_parse_multistatus_mismatched_closing_tag_errors() {
+    // A closing tag that does not match the currently open element must be a hard
+    // parse error instead of silently corrupting the parser state.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:response>
+    <D:href>/dav/user01/event1.ics</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:getetag>"etag-1"</D:getetag>
+      </D:prop>
+    </D:response>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"#;
+
+    let result = parse_multistatus_bytes(xml.as_bytes());
+    assert!(
+        result.is_err(),
+        "mismatched closing tag should be rejected as a parse error"
+    );
 }
 
 #[test]

--- a/tests/unit/caldav/streaming_tests.rs
+++ b/tests/unit/caldav/streaming_tests.rs
@@ -5,6 +5,7 @@ use http_body_util::Full;
 use hyper::Request;
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
+use std::time::{Duration, Instant};
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 
 async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::DavItem>>> {
@@ -149,6 +150,86 @@ fn test_multistatus_visit_error_propagates() {
     let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(anyhow!("boom")));
 
     assert!(err.is_err(), "expected visitor error to propagate");
+}
+
+#[tokio::test]
+async fn test_streaming_stalled_body_times_out() -> Result<()> {
+    let (client_io, mut server_io) = io::duplex(16 * 1024);
+
+    // Server: read the request headers, send response headers plus a partial body,
+    // then stall forever without closing the stream.
+    let server_task = tokio::spawn(async move {
+        let mut buf = [0u8; 1024];
+        let mut seen = Vec::new();
+        loop {
+            let n = server_io.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            seen.extend_from_slice(&buf[..n]);
+            if seen.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+            if seen.len() > 8192 {
+                break;
+            }
+        }
+
+        let header = "HTTP/1.1 207 Multi-Status\r\nContent-Length: 4096\r\nContent-Type: application/xml; charset=utf-8\r\n\r\n";
+        let partial_body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<D:multistatus xmlns:D=\"DAV:\">\n  <D:response>";
+        server_io.write_all(header.as_bytes()).await?;
+        server_io.write_all(partial_body.as_bytes()).await?;
+        server_io.flush().await?;
+        // Keep the connection open so the client observes inactivity, not EOF.
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        Ok::<(), std::io::Error>(())
+    });
+
+    let (mut sender, conn) = http1::handshake(TokioIo::new(client_io)).await?;
+    let conn_task = tokio::spawn(conn);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("http://localhost/")
+        .body(Full::<Bytes>::default())?;
+
+    let resp = sender.send_request(req).await?;
+
+    let start = Instant::now();
+    let result =
+        parse_multistatus_stream_with_timeout(resp.into_body(), &[], Duration::from_millis(100))
+            .await;
+    let elapsed = start.elapsed();
+
+    let err = result.expect_err("stalled stream must produce a timeout error");
+    assert!(
+        err.to_string().contains("timed out"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "idle timeout should fire promptly, waited {elapsed:?}"
+    );
+
+    server_task.abort();
+    conn_task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_truncated_xml_errors() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/cal1/</D:href>"#;
+
+    let err = parse_streaming_xml(xml)
+        .await
+        .expect_err("truncated streaming XML must be rejected");
+    assert!(
+        err.to_string().contains("unclosed element"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]

--- a/tests/unit/carddav/parser_edge_cases.rs
+++ b/tests/unit/carddav/parser_edge_cases.rs
@@ -44,7 +44,6 @@ fn test_parse_multistatus_performance() {
 
 #[test]
 fn test_parse_multistatus_malformed_xml() {
-    // Test with malformed XML
     let malformed_xml = r#"<?xml version="1.0" encoding="utf-8"?>
 <D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
   <D:response>
@@ -56,10 +55,62 @@ fn test_parse_multistatus_malformed_xml() {
       <!-- Missing closing tags -->
 "#;
 
-    let result = parse_multistatus_bytes(malformed_xml.as_bytes());
-    // Depending on the parser implementation, this might either error or partially parse
-    // The important thing is that it doesn't panic or cause undefined behavior
-    println!("Malformed XML parsing result: {:?}", result.is_ok());
+    let err = parse_multistatus_bytes(malformed_xml.as_bytes())
+        .expect_err("truncated XML must be rejected");
+    assert!(
+        err.to_string().contains("unclosed element"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_parse_multistatus_duplicate_attribute_errors() {
+    // quick-xml attribute checks are enabled: a duplicated attribute coming from a
+    // buggy or malicious server must be a parse error, not silently tolerated.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+  <D:response>
+    <D:href>/dav/user01/personal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <C:supported-address-data>
+          <C:address-data-type content-type="text/vcard" content-type="text/x-vcard"/>
+        </C:supported-address-data>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"#;
+
+    let result = parse_multistatus_bytes(xml.as_bytes());
+    assert!(
+        result.is_err(),
+        "duplicated attribute should be rejected as a parse error"
+    );
+}
+
+#[test]
+fn test_parse_multistatus_mismatched_closing_tag_errors() {
+    // A closing tag that does not match the currently open element must be a hard
+    // parse error instead of silently corrupting the parser state.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+  <D:response>
+    <D:href>/dav/user01/contact1.vcf</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:getetag>"etag-1"</D:getetag>
+      </D:prop>
+    </D:response>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"#;
+
+    let result = parse_multistatus_bytes(xml.as_bytes());
+    assert!(
+        result.is_err(),
+        "mismatched closing tag should be rejected as a parse error"
+    );
 }
 
 #[test]

--- a/tests/unit/carddav/streaming_tests.rs
+++ b/tests/unit/carddav/streaming_tests.rs
@@ -5,6 +5,7 @@ use http_body_util::Full;
 use hyper::Request;
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
+use std::time::{Duration, Instant};
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 
 async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::carddav::DavItem>>> {
@@ -149,6 +150,86 @@ fn test_multistatus_visit_error_propagates() {
     let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(anyhow!("boom")));
 
     assert!(err.is_err(), "expected visitor error to propagate");
+}
+
+#[tokio::test]
+async fn test_streaming_stalled_body_times_out() -> Result<()> {
+    let (client_io, mut server_io) = io::duplex(16 * 1024);
+
+    // Server: read the request headers, send response headers plus a partial body,
+    // then stall forever without closing the stream.
+    let server_task = tokio::spawn(async move {
+        let mut buf = [0u8; 1024];
+        let mut seen = Vec::new();
+        loop {
+            let n = server_io.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            seen.extend_from_slice(&buf[..n]);
+            if seen.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+            if seen.len() > 8192 {
+                break;
+            }
+        }
+
+        let header = "HTTP/1.1 207 Multi-Status\r\nContent-Length: 4096\r\nContent-Type: application/xml; charset=utf-8\r\n\r\n";
+        let partial_body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<D:multistatus xmlns:D=\"DAV:\">\n  <D:response>";
+        server_io.write_all(header.as_bytes()).await?;
+        server_io.write_all(partial_body.as_bytes()).await?;
+        server_io.flush().await?;
+        // Keep the connection open so the client observes inactivity, not EOF.
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        Ok::<(), std::io::Error>(())
+    });
+
+    let (mut sender, conn) = http1::handshake(TokioIo::new(client_io)).await?;
+    let conn_task = tokio::spawn(conn);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("http://localhost/")
+        .body(Full::<Bytes>::default())?;
+
+    let resp = sender.send_request(req).await?;
+
+    let start = Instant::now();
+    let result =
+        parse_multistatus_stream_with_timeout(resp.into_body(), &[], Duration::from_millis(100))
+            .await;
+    let elapsed = start.elapsed();
+
+    let err = result.expect_err("stalled stream must produce a timeout error");
+    assert!(
+        err.to_string().contains("timed out"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "idle timeout should fire promptly, waited {elapsed:?}"
+    );
+
+    server_task.abort();
+    conn_task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_truncated_xml_errors() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/book1/</D:href>"#;
+
+    let err = parse_streaming_xml(xml)
+        .await
+        .expect_err("truncated streaming XML must be rejected");
+    assert!(
+        err.to_string().contains("unclosed element"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
fix(streaming): harden multistatus parsing against malformed and stalled responses

- enable quick-xml attribute checks (duplicate attributes now error)
- error on closing-tag/stack mismatches instead of silently corrupting parser state
- drop the residual Response double-pop workaround
- add idle timeout (default 30s) on streaming reads + *_with_timeout variants
- skip non-data HTTP/2 frames (trailers) explicitly