### PR TITLE
Feat/typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,27 +16,27 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -52,15 +52,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -68,14 +68,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -86,15 +87,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -103,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -113,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -125,9 +126,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -137,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -157,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -222,6 +223,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fast-dav-rs"
 version = "0.5.0"
 dependencies = [
@@ -243,15 +254,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -325,7 +336,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -359,25 +370,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -401,26 +411,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -447,9 +456,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -506,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -530,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -540,35 +549,36 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "lock_api"
@@ -581,15 +591,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -603,13 +613,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,15 +633,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -658,21 +668,21 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -689,18 +699,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -719,7 +729,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -727,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -742,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -754,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -775,17 +785,17 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -796,9 +806,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -809,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -819,74 +829,75 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,9 +908,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -908,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -919,29 +930,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -951,25 +962,25 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -977,13 +988,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -996,9 +1008,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1006,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -1021,9 +1033,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "untrusted"
@@ -1047,28 +1059,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.5+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1078,24 +1072,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1103,40 +1083,40 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1153,7 +1133,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1164,29 +1144,29 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1202,18 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -1281,12 +1252,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +225,6 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "fast-dav-rs"
 version = "0.4.4"
 dependencies = [
- "anyhow",
  "async-compression",
  "base64",
  "bytes",
@@ -242,6 +235,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "quick-xml",
+ "thiserror",
  "tokio",
  "tokio-util",
  "zeroize",
@@ -331,7 +325,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -849,7 +843,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -913,6 +907,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +962,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1062,7 +1087,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1084,7 +1109,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1128,7 +1153,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1139,7 +1164,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/Goopil/fast-dav-rs"
 include = ["Cargo.toml", "LICENSE", "/README.md", "src/**/*.rs"]
 
 [dependencies]
-anyhow = "1"
 base64 = "0.22"
 bytes = "1"
 futures = "0.3"
@@ -23,6 +22,7 @@ async-compression = { version = "0.4", features = ["tokio", "brotli", "gzip", "z
 hyper-util = { version = "0.1", features = ["client", "http1", "http2", "tokio"] }
 http-body-util = "0.1"
 zeroize = "1"
+thiserror = "2"
 
 [dev-dependencies]
 tokio = { version = "1.50.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ not fit a specific variant, use [`Error::other`] for a standalone message or
 
 ```rust
 use fast_dav_rs::Error;
+use std::error::Error as _;
 
 let standalone = Error::other("no principal returned");
 let with_cause = Error::with_source("callback failed", std::io::Error::other("disk full"));

--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ not fit a specific variant, use [`Error::other`] for a standalone message or
 
 ```rust
 use fast_dav_rs::Error;
-use std::error::Error as _;
 
 let standalone = Error::other("no principal returned");
 let with_cause = Error::with_source("callback failed", std::io::Error::other("disk full"));

--- a/README.md
+++ b/README.md
@@ -162,8 +162,12 @@ async fn main() -> Result<()> {
 ## Error Handling & Migration
 
 Public APIs return `fast_dav_rs::Result<T>`, whose error type is the public
-`fast_dav_rs::Error` enum. Applications can match its variants to make decisions
-without inspecting error messages or downcasting an opaque error:
+`fast_dav_rs::Error` enum. The enum is `#[non_exhaustive]`, so always include a
+wildcard arm (`_ => …`) when matching — new variants may be added in future
+releases without a breaking change.
+
+Applications can match its variants to make decisions without inspecting error
+messages or downcasting an opaque error:
 
 ```rust
 use fast_dav_rs::Error;
@@ -172,6 +176,28 @@ fn is_retryable(error: &Error) -> bool {
     matches!(error, Error::Timeout { .. } | Error::Transport(_))
 }
 ```
+
+### Error variants
+
+| Variant              | When it occurs                                              |
+|----------------------|-------------------------------------------------------------|
+| `InvalidUrl`         | A base URL or resolved request URI is invalid               |
+| `InvalidInput`       | A caller-provided value failed validation (ETag, dates, …)  |
+| `InvalidHeader`      | An HTTP header value could not be constructed               |
+| `InvalidMethod`      | An HTTP method was invalid                                  |
+| `Http`               | Building an HTTP request failed                             |
+| `Hyper`              | A low-level Hyper connection or body operation failed       |
+| `Connection`         | The TCP/TLS handshake failed (DNS, refused, TLS)            |
+| `Transport`          | A request was sent but the response stream broke            |
+| `UnexpectedStatus`   | The server returned an unexpected HTTP status code          |
+| `Timeout`            | An operation exceeded its configured time limit            |
+| `Xml`                | Parsing or decoding XML failed                              |
+| `XmlStructure`       | The XML element hierarchy is malformed or incomplete        |
+| `XmlEscape`          | Unescaping XML entity references failed                    |
+| `XmlAttribute`       | Parsing an XML attribute failed                             |
+| `Io`                 | An I/O operation failed                                     |
+| `Utf8`               | Decoding UTF-8 text failed                                   |
+| `Other`              | User callback error or error that doesn't fit another variant |
 
 ### Migrating from `anyhow`
 
@@ -245,6 +271,65 @@ use fast_dav_rs::Error;
 let standalone = Error::other("no principal returned");
 let with_cause = Error::with_source("callback failed", std::io::Error::other("disk full"));
 assert!(with_cause.source().is_some());
+```
+
+### Custom errors in streaming callbacks
+
+When using streaming APIs with a visitor callback, return `Error::other` for
+application-level failures and `Error::with_source` to wrap an underlying cause:
+
+```rust,no_run
+use fast_dav_rs::{CalDavClient, Depth, Error, Result};
+use fast_dav_rs::caldav::{parse_multistatus_stream_visit, DavItem};
+
+async fn sync_calendar(client: &CalDavClient, path: &str) -> Result<()> {
+    let resp = client.report(path, Depth::One, "<body/>").await?;
+
+    parse_multistatus_stream_visit(resp.into_body(), &[], |item: DavItem| {
+        // Save to a database; wrap the DB error with context.
+        save_to_db(&item).map_err(|e| {
+            Error::with_source(format!("failed to save {}", item.href), e)
+        })
+    }).await?;
+
+    Ok(())
+}
+
+fn save_to_db(_item: &DavItem) -> std::result::Result<(), DbError> {
+    Ok(())
+}
+
+#[derive(Debug)]
+struct DbError;
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "database error")
+    }
+}
+impl std::error::Error for DbError {}
+```
+
+### Migrating from `anyhow` with `map_err`
+
+If your codebase uses `anyhow::Context` to add context to library errors,
+replace `.context("...")` with `.map_err(|e| Error::with_source("...", e))`:
+
+```rust
+// Before (anyhow)
+use anyhow::Context;
+let principal = client
+    .discover_current_user_principal()
+    .await
+    .context("discovery failed")?
+    .ok_or_else(|| anyhow::anyhow!("no principal"))?;
+
+// After (typed errors)
+use fast_dav_rs::Error;
+let principal = client
+    .discover_current_user_principal()
+    .await
+    .map_err(|e| Error::with_source("discovery failed", e))?
+    .ok_or_else(|| Error::other("no principal"))?;
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -209,6 +209,44 @@ Replace calls specific to `anyhow::Error`, such as `downcast_ref`, `context`, or
 messages remain intended for diagnostics; use variants and their fields for
 programmatic handling.
 
+### Distinguishing connection vs transport errors
+
+`Error::Connection` is returned when the TCP/TLS handshake itself fails (DNS
+resolution, connection refused, TLS error), while `Error::Transport` covers
+failures during an already-established connection (read/write abort, body
+decode error). This lets retry logic target only transient connection issues:
+
+```rust
+use fast_dav_rs::Error;
+
+fn should_retry(error: &Error) -> bool {
+    match error {
+        // The server was unreachable; a retry may reach a different node.
+        Error::Connection(_) | Error::Timeout { .. } => true,
+        // The request was sent but the response stream broke mid-flight.
+        // Retrying is only safe for idempotent methods (GET, PUT with If-Match).
+        Error::Transport(_) => false,
+        // The server explicitly rejected the request.
+        Error::UnexpectedStatus { status, .. } => {
+            status.is_server_error()
+        }
+        _ => false,
+    }
+}
+```
+
+For errors originating in user callbacks or when wrapping an error that does
+not fit a specific variant, use [`Error::other`] for a standalone message or
+[`Error::with_source`] to preserve the underlying cause in the error chain:
+
+```rust
+use fast_dav_rs::Error;
+
+let standalone = Error::other("no principal returned");
+let with_cause = Error::with_source("callback failed", std::io::Error::other("disk full"));
+assert!(with_cause.source().is_some());
+```
+
 ## Configuration
 
 ### Request compression

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ features, and major releases introduce breaking changes when needed.
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Error Handling & Migration](#error-handling--migration)
 - [Configuration](#configuration)
 - [Security](#security)
 - [Usage Examples](#usage-examples)
@@ -103,8 +104,7 @@ cargo add fast-dav-rs
 ### CalDAV discovery
 
 ```rust
-use fast_dav_rs::CalDavClient;
-use anyhow::Result;
+use fast_dav_rs::{CalDavClient, Error, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
     let principal = client
         .discover_current_user_principal()
         .await?
-        .ok_or_else(|| anyhow::anyhow!("no principal returned"))?;
+        .ok_or_else(|| Error::other("no principal returned"))?;
 
     let homes = client.discover_calendar_home_set(&principal).await?;
     let home = homes.first().expect("missing calendar-home-set");
@@ -133,8 +133,7 @@ async fn main() -> Result<()> {
 ### CardDAV discovery
 
 ```rust
-use fast_dav_rs::CardDavClient;
-use anyhow::Result;
+use fast_dav_rs::{CardDavClient, Error, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -147,7 +146,7 @@ async fn main() -> Result<()> {
     let principal = client
         .discover_current_user_principal()
         .await?
-        .ok_or_else(|| anyhow::anyhow!("no principal returned"))?;
+        .ok_or_else(|| Error::other("no principal returned"))?;
 
     let homes = client.discover_addressbook_home_set(&principal).await?;
     let home = homes.first().expect("missing addressbook-home-set");
@@ -159,6 +158,56 @@ async fn main() -> Result<()> {
     Ok(())
 }
 ```
+
+## Error Handling & Migration
+
+Public APIs return `fast_dav_rs::Result<T>`, whose error type is the public
+`fast_dav_rs::Error` enum. Applications can match its variants to make decisions
+without inspecting error messages or downcasting an opaque error:
+
+```rust
+use fast_dav_rs::Error;
+
+fn is_retryable(error: &Error) -> bool {
+    matches!(error, Error::Timeout { .. } | Error::Transport(_))
+}
+```
+
+### Migrating from `anyhow`
+
+Earlier releases returned `anyhow::Error`. Replace library-facing
+`anyhow::Result<T>` signatures with `fast_dav_rs::Result<T>` when you want to
+preserve and match the typed error:
+
+```rust
+use fast_dav_rs::{CalDavClient, Error, Result};
+
+async fn discover_principal(client: &CalDavClient) -> Result<String> {
+    client
+        .discover_current_user_principal()
+        .await?
+        .ok_or_else(|| Error::other("no principal returned"))
+}
+```
+
+Applications that use `anyhow` at their own boundary can continue to propagate
+library errors with `?`; `fast_dav_rs::Error` implements `std::error::Error`:
+
+```rust
+use anyhow::Result;
+use fast_dav_rs::CalDavClient;
+
+async fn synchronize(client: &CalDavClient) -> Result<()> {
+    client.discover_current_user_principal().await?;
+    Ok(())
+}
+```
+
+Replace calls specific to `anyhow::Error`, such as `downcast_ref`, `context`, or
+`with_context`, with pattern matching on variants such as `Error::Timeout`,
+`Error::UnexpectedStatus`, `Error::InvalidInput`, and `Error::Transport`. Error
+messages remain intended for diagnostics; use variants and their fields for
+programmatic handling.
 
 ## Configuration
 
@@ -198,9 +247,8 @@ bundled Docker setup), so the library does not reject `http://` at runtime — *
 ### CalDAV event CRUD
 
 ```rust
-use fast_dav_rs::CalDavClient;
+use fast_dav_rs::{CalDavClient, Result};
 use bytes::Bytes;
-use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -229,9 +277,8 @@ async fn main() -> Result<()> {
 ### CardDAV contact CRUD
 
 ```rust
-use fast_dav_rs::CardDavClient;
+use fast_dav_rs::{CardDavClient, Result};
 use bytes::Bytes;
-use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -266,9 +313,8 @@ async fn main() -> Result<()> {
 ### CalDAV streaming example
 
 ```rust
-use fast_dav_rs::{CalDavClient, Depth, detect_encoding};
+use fast_dav_rs::{CalDavClient, Depth, Result, detect_encoding};
 use fast_dav_rs::caldav::parse_multistatus_stream;
-use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -292,9 +338,8 @@ async fn main() -> Result<()> {
 ### CardDAV streaming example
 
 ```rust
-use fast_dav_rs::{CardDavClient, Depth, detect_encoding};
+use fast_dav_rs::{CardDavClient, Depth, Result, detect_encoding};
 use fast_dav_rs::carddav::parse_multistatus_stream;
-use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -318,10 +363,9 @@ async fn main() -> Result<()> {
 ## Batch Operations
 
 ```rust
-use fast_dav_rs::{CalDavClient, Depth};
+use fast_dav_rs::{CalDavClient, Depth, Result};
 use bytes::Bytes;
 use std::sync::Arc;
-use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -462,18 +462,12 @@ impl CalDavClient {
         end: Option<&str>,
         include_data: bool,
     ) -> Result<Vec<CalendarObject>> {
-        validate_component_name(component).map_err(|error| {
-            Error::InvalidInput(format!("invalid calendar-query component: {error}"))
-        })?;
+        validate_component_name(component, "invalid calendar-query component")?;
         if let Some(s) = start {
-            validate_utc_datetime(s).map_err(|error| {
-                Error::InvalidInput(format!("invalid calendar-query start: {error}"))
-            })?;
+            validate_utc_datetime(s, "invalid calendar-query start")?;
         }
         if let Some(e) = end {
-            validate_utc_datetime(e).map_err(|error| {
-                Error::InvalidInput(format!("invalid calendar-query end: {error}"))
-            })?;
+            validate_utc_datetime(e, "invalid calendar-query end")?;
         }
 
         let xml = build_calendar_query_body(component, start, end, include_data);

--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::{HeaderMap, Method, Response, Uri, header};
@@ -13,6 +12,7 @@ use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
 use crate::webdav::types::http_status_code;
 use crate::webdav::xml::{validate_component_name, validate_utc_datetime};
+use crate::{Error, Result};
 
 pub use crate::webdav::client::RequestCompressionMode;
 
@@ -62,7 +62,7 @@ impl CalDavClient {
     /// # Example
     /// ```no_run
     /// use fast_dav_rs::CalDavClient;
-    /// use anyhow::Result;
+    /// use fast_dav_rs::Result;
     ///
     /// # async fn example() -> Result<()> {
     /// let client = CalDavClient::new(
@@ -90,7 +90,7 @@ impl CalDavClient {
     /// ```no_run
     /// use fast_dav_rs::{CalDavClient, ContentEncoding};
     ///
-    /// # fn example() -> anyhow::Result<()> {
+    /// # fn example() -> fast_dav_rs::Result<()> {
     /// let mut client = CalDavClient::new(
     ///     "https://cal.example.com/dav/user01/",
     ///     Some("user01"),
@@ -145,7 +145,7 @@ impl CalDavClient {
     /// # use hyper::{Method, HeaderMap};
     /// # use bytes::Bytes;
     /// #
-    /// # async fn demo(cli: &CalDavClient) -> anyhow::Result<()> {
+    /// # async fn demo(cli: &CalDavClient) -> fast_dav_rs::Result<()> {
     /// let res = cli.send(Method::GET, "Calendars/Personal/", HeaderMap::new(), None, None).await?;
     /// assert!(res.status().is_success());
     /// # Ok(())
@@ -237,7 +237,7 @@ impl CalDavClient {
     ) -> Result<Response<Bytes>> {
         // Validate ETag doesn't contain forbidden characters
         if etag.is_empty() {
-            return Err(anyhow!("ETag cannot be empty"));
+            return Err(Error::InvalidInput("ETag cannot be empty".to_owned()));
         }
 
         let mut h = HeaderMap::new();
@@ -366,10 +366,10 @@ impl CalDavClient {
 "#;
         let resp = self.propfind("", Depth::Zero, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "PROPFIND current-user-principal failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND current-user-principal".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         let mut principal = None;
@@ -397,10 +397,10 @@ impl CalDavClient {
 "#;
         let resp = self.propfind(principal_path, Depth::Zero, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "PROPFIND calendar-home-set failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND calendar-home-set".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         let mut homes = Vec::new();
@@ -431,7 +431,10 @@ impl CalDavClient {
 "#;
         let resp = self.propfind(home_set_path, Depth::One, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!("PROPFIND calendars failed with {}", resp.status()));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND calendars".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_calendar_list(parse_multistatus_bytes(&body)?.items))
@@ -463,23 +466,28 @@ impl CalDavClient {
         end: Option<&str>,
         include_data: bool,
     ) -> Result<Vec<CalendarObject>> {
-        validate_component_name(component)
-            .map_err(|e| anyhow!("invalid calendar-query component: {e}"))?;
+        validate_component_name(component).map_err(|error| {
+            Error::InvalidInput(format!("invalid calendar-query component: {error}"))
+        })?;
         if let Some(s) = start {
-            validate_utc_datetime(s).map_err(|e| anyhow!("invalid calendar-query start: {e}"))?;
+            validate_utc_datetime(s).map_err(|error| {
+                Error::InvalidInput(format!("invalid calendar-query start: {error}"))
+            })?;
         }
         if let Some(e) = end {
-            validate_utc_datetime(e).map_err(|e| anyhow!("invalid calendar-query end: {e}"))?;
+            validate_utc_datetime(e).map_err(|error| {
+                Error::InvalidInput(format!("invalid calendar-query end: {error}"))
+            })?;
         }
 
         let xml = build_calendar_query_body(component, start, end, include_data);
 
         let resp = self.report(calendar_path, Depth::One, &xml).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT calendar-query failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT calendar-query".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_calendar_objects(parse_multistatus_bytes(&body)?.items))
@@ -502,10 +510,10 @@ impl CalDavClient {
 
         let resp = self.report(calendar_path, Depth::One, &body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT calendar-multiget failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT calendar-multiget".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_calendar_objects(parse_multistatus_bytes(&body)?.items))
@@ -523,10 +531,10 @@ impl CalDavClient {
 
         let resp = self.report(calendar_path, Depth::One, &body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT sync-collection failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT sync-collection".to_owned(),
+                status: resp.status(),
+            });
         }
         let headers = resp.headers().clone();
         let body = resp.into_body();
@@ -590,7 +598,7 @@ impl CalDavClient {
     ///
     /// ```no_run
     /// # use fast_dav_rs::CalDavClient;
-    /// # use anyhow::Result;
+    /// # use fast_dav_rs::Result;
     /// #
     /// # async fn example() -> Result<()> {
     /// # let client = CalDavClient::new("https://example.com/", None, None)?;

--- a/src/caldav/streaming.rs
+++ b/src/caldav/streaming.rs
@@ -1,7 +1,7 @@
 use crate::caldav::types::DavItem;
 use crate::common::compression::ContentEncoding;
 use crate::webdav::streaming::{CommonParser, path_ends_with};
-use anyhow::{Result, anyhow};
+use crate::{Error, Result};
 use futures::TryStreamExt;
 use http_body_util::BodyStream;
 use hyper::body::Incoming;
@@ -155,9 +155,9 @@ impl<C: ItemConsumer> MultistatusParser<C> {
 
     fn finish(self) -> Result<ParseResult<C>> {
         if let Some(unclosed) = self.stack.last() {
-            return Err(anyhow!(
-                "XML structure error: unexpected end of input with unclosed element {unclosed:?}"
-            ));
+            return Err(Error::XmlStructure(format!(
+                "unexpected end of input with unclosed element {unclosed:?}"
+            )));
         }
 
         Ok(ParseResult {
@@ -205,7 +205,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     if key == "name" {
                         let value = attr
                             .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|e| anyhow!("Invalid XML attribute: {e}"))?
+                            .map_err(|error| Error::XmlDecode(error.to_string()))?
                             .into_owned();
                         if !value.is_empty()
                             && !self
@@ -352,8 +352,8 @@ where
     loop {
         let event = tokio::time::timeout(idle_timeout, xml.read_event_into_async(&mut buf))
             .await
-            .map_err(|_| {
-                anyhow!("streaming read timed out after {idle_timeout:?} of inactivity")
+            .map_err(|_| Error::Timeout {
+                limit: idle_timeout,
             })?;
         match event {
             Ok(Event::Start(e)) => parser.on_start(&e, xml.decoder())?,
@@ -371,7 +371,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(e) => return Err(anyhow!("XML parsing error: {e}")),
+            Err(error) => return Err(error.into()),
             _ => {}
         }
         buf.clear();
@@ -408,7 +408,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(e) => return Err(anyhow!("XML error: {e}")),
+            Err(error) => return Err(error.into()),
             _ => {}
         }
         buf.clear();
@@ -505,7 +505,7 @@ where
 pub fn decode_text(raw: &[u8]) -> Result<String> {
     match std::str::from_utf8(raw) {
         Ok(s) => Ok(unescape(s)
-            .map_err(|err| anyhow!("XML decode error: {err}"))?
+            .map_err(|error| Error::XmlDecode(error.to_string()))?
             .into_owned()),
         Err(_) => Ok(String::from_utf8_lossy(raw).into_owned()),
     }

--- a/src/caldav/streaming.rs
+++ b/src/caldav/streaming.rs
@@ -204,8 +204,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     let key = String::from_utf8_lossy(attr.key.as_ref()).to_ascii_lowercase();
                     if key == "name" {
                         let value = attr
-                            .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|error| Error::XmlDecode(error.to_string()))?
+                            .decoded_and_normalized_value(XmlVersion::default(), decoder)?
                             .into_owned();
                         if !value.is_empty()
                             && !self
@@ -504,9 +503,7 @@ where
 
 pub fn decode_text(raw: &[u8]) -> Result<String> {
     match std::str::from_utf8(raw) {
-        Ok(s) => Ok(unescape(s)
-            .map_err(|error| Error::XmlDecode(error.to_string()))?
-            .into_owned()),
+        Ok(s) => Ok(unescape(s)?.into_owned()),
         Err(_) => Ok(String::from_utf8_lossy(raw).into_owned()),
     }
 }

--- a/src/caldav/streaming.rs
+++ b/src/caldav/streaming.rs
@@ -370,7 +370,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(Error::from_quick_xml(error)),
             _ => {}
         }
         buf.clear();
@@ -407,7 +407,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(Error::from_quick_xml(error)),
             _ => {}
         }
         buf.clear();

--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::{HeaderMap, Method, Response, StatusCode, Uri, header};
@@ -12,6 +11,7 @@ use crate::carddav::types::{
 use crate::common::compression::ContentEncoding;
 use crate::webdav::client::WebDavClient;
 use crate::webdav::types::http_status_code;
+use crate::{Error, Result};
 
 pub use crate::webdav::client::RequestCompressionMode;
 
@@ -61,7 +61,7 @@ impl CardDavClient {
     /// # Example
     /// ```no_run
     /// use fast_dav_rs::CardDavClient;
-    /// use anyhow::Result;
+    /// use fast_dav_rs::Result;
     ///
     /// # async fn example() -> Result<()> {
     /// let client = CardDavClient::new(
@@ -89,7 +89,7 @@ impl CardDavClient {
     /// ```no_run
     /// use fast_dav_rs::{CardDavClient, ContentEncoding};
     ///
-    /// # fn example() -> anyhow::Result<()> {
+    /// # fn example() -> fast_dav_rs::Result<()> {
     /// let mut client = CardDavClient::new(
     ///     "https://card.example.com/dav/user01/",
     ///     Some("user01"),
@@ -144,7 +144,7 @@ impl CardDavClient {
     /// # use hyper::{Method, HeaderMap};
     /// # use bytes::Bytes;
     /// #
-    /// # async fn demo(cli: &CardDavClient) -> anyhow::Result<()> {
+    /// # async fn demo(cli: &CardDavClient) -> fast_dav_rs::Result<()> {
     /// let res = cli.send(Method::GET, "Calendars/Personal/", HeaderMap::new(), None, None).await?;
     /// assert!(res.status().is_success());
     /// # Ok(())
@@ -236,7 +236,7 @@ impl CardDavClient {
     ) -> Result<Response<Bytes>> {
         // Validate ETag doesn't contain forbidden characters
         if etag.is_empty() {
-            return Err(anyhow!("ETag cannot be empty"));
+            return Err(Error::InvalidInput("ETag cannot be empty".to_owned()));
         }
 
         let mut h = HeaderMap::new();
@@ -386,10 +386,10 @@ impl CardDavClient {
 "#;
         let resp = self.propfind("", Depth::Zero, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "PROPFIND current-user-principal failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND current-user-principal".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         let mut principal = None;
@@ -417,10 +417,10 @@ impl CardDavClient {
 "#;
         let resp = self.propfind(principal_path, Depth::Zero, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "PROPFIND addressbook-home-set failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND addressbook-home-set".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         let mut homes = Vec::new();
@@ -450,10 +450,10 @@ impl CardDavClient {
 "#;
         let resp = self.propfind(home_set_path, Depth::One, body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "PROPFIND addressbooks failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "PROPFIND addressbooks".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_addressbook_list(parse_multistatus_bytes(&body)?.items))
@@ -470,10 +470,10 @@ impl CardDavClient {
 
         let resp = self.report(addressbook_path, Depth::One, &xml).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT addressbook-query failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT addressbook-query".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_address_objects(parse_multistatus_bytes(&body)?.items))
@@ -532,10 +532,10 @@ impl CardDavClient {
 
         let resp = self.report(addressbook_path, Depth::One, &body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT addressbook-multiget failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT addressbook-multiget".to_owned(),
+                status: resp.status(),
+            });
         }
         let body = resp.into_body();
         Ok(map_address_objects(parse_multistatus_bytes(&body)?.items))
@@ -553,10 +553,10 @@ impl CardDavClient {
 
         let resp = self.report(addressbook_path, Depth::One, &body).await?;
         if !resp.status().is_success() {
-            return Err(anyhow!(
-                "REPORT sync-collection failed with {}",
-                resp.status()
-            ));
+            return Err(Error::UnexpectedStatus {
+                operation: "REPORT sync-collection".to_owned(),
+                status: resp.status(),
+            });
         }
         let headers = resp.headers().clone();
         let body = resp.into_body();
@@ -620,7 +620,7 @@ impl CardDavClient {
     ///
     /// ```no_run
     /// # use fast_dav_rs::CardDavClient;
-    /// # use anyhow::Result;
+    /// # use fast_dav_rs::Result;
     /// #
     /// # async fn example() -> Result<()> {
     /// # let client = CardDavClient::new("https://example.com/", None, None)?;

--- a/src/carddav/streaming.rs
+++ b/src/carddav/streaming.rs
@@ -203,16 +203,14 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     let key = String::from_utf8_lossy(attr.key.as_ref()).to_ascii_lowercase();
                     if key == "content-type" {
                         let value = attr
-                            .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|error| Error::XmlDecode(error.to_string()))?
+                            .decoded_and_normalized_value(XmlVersion::default(), decoder)?
                             .into_owned();
                         if !value.is_empty() {
                             content_type = Some(value);
                         }
                     } else if key == "version" {
                         let value = attr
-                            .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|error| Error::XmlDecode(error.to_string()))?
+                            .decoded_and_normalized_value(XmlVersion::default(), decoder)?
                             .into_owned();
                         if !value.is_empty() {
                             version = Some(value);
@@ -505,9 +503,7 @@ where
 
 pub fn decode_text(raw: &[u8]) -> Result<String> {
     match std::str::from_utf8(raw) {
-        Ok(s) => Ok(unescape(s)
-            .map_err(|error| Error::XmlDecode(error.to_string()))?
-            .into_owned()),
+        Ok(s) => Ok(unescape(s)?.into_owned()),
         Err(_) => Ok(String::from_utf8_lossy(raw).into_owned()),
     }
 }

--- a/src/carddav/streaming.rs
+++ b/src/carddav/streaming.rs
@@ -1,7 +1,7 @@
 use crate::carddav::types::DavItem;
 use crate::common::compression::ContentEncoding;
 use crate::webdav::streaming::{CommonParser, path_ends_with};
-use anyhow::{Result, anyhow};
+use crate::{Error, Result};
 use futures::TryStreamExt;
 use http_body_util::BodyStream;
 use hyper::body::Incoming;
@@ -152,9 +152,9 @@ impl<C: ItemConsumer> MultistatusParser<C> {
 
     fn finish(self) -> Result<ParseResult<C>> {
         if let Some(unclosed) = self.stack.last() {
-            return Err(anyhow!(
-                "XML structure error: unexpected end of input with unclosed element {unclosed:?}"
-            ));
+            return Err(Error::XmlStructure(format!(
+                "unexpected end of input with unclosed element {unclosed:?}"
+            )));
         }
 
         Ok(ParseResult {
@@ -204,7 +204,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     if key == "content-type" {
                         let value = attr
                             .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|e| anyhow!("Invalid XML attribute: {e}"))?
+                            .map_err(|error| Error::XmlDecode(error.to_string()))?
                             .into_owned();
                         if !value.is_empty() {
                             content_type = Some(value);
@@ -212,7 +212,7 @@ impl<C: ItemConsumer> MultistatusParser<C> {
                     } else if key == "version" {
                         let value = attr
                             .decoded_and_normalized_value(XmlVersion::default(), decoder)
-                            .map_err(|e| anyhow!("Invalid XML attribute: {e}"))?
+                            .map_err(|error| Error::XmlDecode(error.to_string()))?
                             .into_owned();
                         if !value.is_empty() {
                             version = Some(value);
@@ -353,8 +353,8 @@ where
     loop {
         let event = tokio::time::timeout(idle_timeout, xml.read_event_into_async(&mut buf))
             .await
-            .map_err(|_| {
-                anyhow!("streaming read timed out after {idle_timeout:?} of inactivity")
+            .map_err(|_| Error::Timeout {
+                limit: idle_timeout,
             })?;
         match event {
             Ok(Event::Start(e)) => parser.on_start(&e, xml.decoder())?,
@@ -372,7 +372,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(e) => return Err(anyhow!("XML parsing error: {e}")),
+            Err(error) => return Err(error.into()),
             _ => {}
         }
         buf.clear();
@@ -409,7 +409,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(e) => return Err(anyhow!("XML error: {e}")),
+            Err(error) => return Err(error.into()),
             _ => {}
         }
         buf.clear();
@@ -506,7 +506,7 @@ where
 pub fn decode_text(raw: &[u8]) -> Result<String> {
     match std::str::from_utf8(raw) {
         Ok(s) => Ok(unescape(s)
-            .map_err(|err| anyhow!("XML decode error: {err}"))?
+            .map_err(|error| Error::XmlDecode(error.to_string()))?
             .into_owned()),
         Err(_) => Ok(String::from_utf8_lossy(raw).into_owned()),
     }

--- a/src/carddav/streaming.rs
+++ b/src/carddav/streaming.rs
@@ -370,7 +370,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(Error::from_quick_xml(error)),
             _ => {}
         }
         buf.clear();
@@ -407,7 +407,7 @@ where
             }
             Ok(Event::End(e)) => parser.on_end(e.name().as_ref())?,
             Ok(Event::Eof) => break,
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(Error::from_quick_xml(error)),
             _ => {}
         }
         buf.clear();

--- a/src/common/compression.rs
+++ b/src/common/compression.rs
@@ -3,7 +3,6 @@
 //! This module provides support for automatic compression and decompression
 //! of HTTP responses using various encoding formats.
 
-use anyhow::Result;
 use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZstdDecoder};
 use bytes::Bytes;
 use futures::TryStreamExt;
@@ -13,6 +12,8 @@ use hyper::{HeaderMap, header, http};
 use std::io::Cursor;
 use tokio::io::{AsyncBufRead, AsyncReadExt, BufReader};
 use tokio_util::io::StreamReader;
+
+use crate::Result;
 
 /// Supported content encodings for streaming decompression.
 ///

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
+
+use crate::Result;
 
 /// Type alias for the Hyper client used across CalDAV/CardDAV modules.
 pub type HyperClient = Client<hyper_rustls::HttpsConnector<HttpConnector>, Full<Bytes>>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,128 @@
+use hyper::StatusCode;
+use std::fmt;
+use std::time::Duration;
+
+/// Error returned by `fast-dav-rs` operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A base URL or resolved request URI is invalid.
+    #[error("invalid URL `{url}`: {source}")]
+    InvalidUrl {
+        /// The URL value that failed validation.
+        url: String,
+        /// The URI parser error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// A caller-provided value failed validation.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    /// An HTTP header value is invalid.
+    #[error("invalid HTTP header value: {0}")]
+    InvalidHeader(#[from] hyper::http::header::InvalidHeaderValue),
+
+    /// An HTTP method is invalid.
+    #[error("invalid HTTP method: {0}")]
+    InvalidMethod(#[from] hyper::http::method::InvalidMethod),
+
+    /// Building an HTTP request failed.
+    #[error("HTTP request error: {0}")]
+    Http(#[from] hyper::http::Error),
+
+    /// A low-level Hyper connection or body operation failed.
+    #[error("Hyper error: {0}")]
+    Hyper(#[from] hyper::Error),
+
+    /// Establishing the connection failed.
+    #[error("connection error: {0}")]
+    Connection(#[source] hyper_util::client::legacy::Error),
+
+    /// Sending a request or receiving its body failed.
+    #[error("transport error: {0}")]
+    Transport(#[source] hyper_util::client::legacy::Error),
+
+    /// A DAV operation returned an unexpected HTTP status.
+    #[error("{operation} failed with {status}")]
+    UnexpectedStatus {
+        /// The operation that failed.
+        operation: String,
+        /// The status returned by the server.
+        status: StatusCode,
+    },
+
+    /// An operation exceeded its configured time limit.
+    #[error("operation timed out after {limit:?}")]
+    Timeout {
+        /// The configured time limit.
+        limit: Duration,
+    },
+
+    /// Parsing or decoding XML failed.
+    #[error("XML error: {0}")]
+    Xml(#[from] quick_xml::Error),
+
+    /// The XML element hierarchy is malformed or incomplete.
+    #[error("XML structure error: {0}")]
+    XmlStructure(String),
+
+    /// XML text or an attribute value could not be decoded.
+    #[error("XML decoding error: {0}")]
+    XmlDecode(String),
+
+    /// Parsing an XML attribute failed.
+    #[error("XML attribute error: {0}")]
+    XmlAttribute(#[from] quick_xml::events::attributes::AttrError),
+
+    /// An I/O operation failed.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Decoding UTF-8 text failed.
+    #[error("UTF-8 decoding error: {0}")]
+    Utf8(#[from] std::str::Utf8Error),
+
+    /// An error returned by user-provided callback code.
+    #[error("{0}")]
+    Other(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl Error {
+    pub(crate) fn invalid_url(
+        url: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::InvalidUrl {
+            url: url.into(),
+            source: Box::new(source),
+        }
+    }
+
+    pub(crate) fn from_client(source: hyper_util::client::legacy::Error) -> Self {
+        if source.is_connect() {
+            Self::Connection(source)
+        } else {
+            Self::Transport(source)
+        }
+    }
+
+    /// Wrap an error message originating outside the DAV protocol stack.
+    pub fn other(message: impl Into<String>) -> Self {
+        Self::Other(Box::new(MessageError(message.into())))
+    }
+}
+
+#[derive(Debug)]
+struct MessageError(String);
+
+impl fmt::Display for MessageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for MessageError {}
+
+/// Result type used by all fallible `fast-dav-rs` APIs.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,8 +146,8 @@ impl Error {
 
     /// Wrap an error with a context message and an underlying source.
     ///
-    /// The context is used for `Display`; the source is returned by `source()`
-    /// so the full error chain is preserved.
+    /// The context is used for `Display`; the source is returned by
+    /// [`Error::source`] so the full error chain is preserved.
     pub fn with_source(
         context: impl Into<String>,
         source: impl std::error::Error + Send + Sync + 'static,
@@ -156,6 +156,15 @@ impl Error {
             context: context.into(),
             source: Some(Box::new(source)),
         }
+    }
+
+    /// Return the underlying cause of this error, if any.
+    ///
+    /// This is an inherent method so that callers do not need to import the
+    /// `std::error::Error` trait. It delegates to the trait implementation
+    /// and is therefore equivalent to `<Error as std::error::Error>::source(self)`.
+    pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        <Self as std::error::Error>::source(self)
     }
 
     /// Convert a `quick_xml::Error` into the most specific `Error` variant.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use hyper::StatusCode;
-use std::fmt;
 use std::time::Duration;
 
 /// Error returned by `fast-dav-rs` operations.
@@ -67,9 +66,9 @@ pub enum Error {
     #[error("XML structure error: {0}")]
     XmlStructure(String),
 
-    /// XML text or an attribute value could not be decoded.
-    #[error("XML decoding error: {0}")]
-    XmlDecode(String),
+    /// Unescaping XML entity references failed.
+    #[error("XML escape error: {0}")]
+    XmlEscape(#[from] quick_xml::escape::EscapeError),
 
     /// Parsing an XML attribute failed.
     #[error("XML attribute error: {0}")]
@@ -83,9 +82,16 @@ pub enum Error {
     #[error("UTF-8 decoding error: {0}")]
     Utf8(#[from] std::str::Utf8Error),
 
-    /// An error returned by user-provided callback code.
-    #[error("{0}")]
-    Other(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// An error returned by user-provided callback code or when wrapping an
+    /// error that does not fit any other variant.
+    #[error("{context}")]
+    Other {
+        /// Human-readable context describing where or why the error occurred.
+        context: String,
+        /// The underlying error, if any.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 }
 
 impl Error {
@@ -108,21 +114,29 @@ impl Error {
     }
 
     /// Wrap an error message originating outside the DAV protocol stack.
+    ///
+    /// Use [`Error::with_source`] when you have an underlying error to chain.
     pub fn other(message: impl Into<String>) -> Self {
-        Self::Other(Box::new(MessageError(message.into())))
+        Self::Other {
+            context: message.into(),
+            source: None,
+        }
+    }
+
+    /// Wrap an error with a context message and an underlying source.
+    ///
+    /// The context is used for `Display`; the source is returned by `source()`
+    /// so the full error chain is preserved.
+    pub fn with_source(
+        context: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Other {
+            context: context.into(),
+            source: Some(Box::new(source)),
+        }
     }
 }
-
-#[derive(Debug)]
-struct MessageError(String);
-
-impl fmt::Display for MessageError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for MessageError {}
 
 /// Result type used by all fallible `fast-dav-rs` APIs.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,14 @@ use hyper::StatusCode;
 use std::time::Duration;
 
 /// Error returned by `fast-dav-rs` operations.
+///
+/// The enum is [`#[non_exhaustive`][ne]] so that new variants can be added
+/// without breaking downstream `match` expressions. Always include a
+/// wildcard arm (`_ => …`) when matching.
+///
+/// [ne]: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// A base URL or resolved request URI is invalid.
     #[error("invalid URL `{url}`: {source}")]
@@ -84,6 +91,11 @@ pub enum Error {
 
     /// An error returned by user-provided callback code or when wrapping an
     /// error that does not fit any other variant.
+    ///
+    /// The `context` string is used for `Display`; the underlying `source` is
+    /// accessible only via [`std::error::Error::source`]. This intentionally
+    /// avoids leaking the cause into the `Display` output, but consumers that
+    /// print errors should walk the source chain to avoid losing information.
     #[error("{context}")]
     Other {
         /// Human-readable context describing where or why the error occurred.
@@ -105,6 +117,15 @@ impl Error {
         }
     }
 
+    /// Classify a `hyper_util` client error as [`Connection`](Self::Connection)
+    /// or [`Transport`](Self::Transport).
+    ///
+    /// Only `ErrorKind::Connect` is mapped to `Connection`. All other kinds —
+    /// including `SendRequest`, which *may* indicate the request never reached
+    /// the server — are mapped to `Transport`. Consumers that need to
+    /// distinguish "request possibly not sent" from "response stream broken"
+    /// should inspect the `hyper_util` error via `source()` rather than
+    /// relying solely on the variant.
     pub(crate) fn from_client(source: hyper_util::client::legacy::Error) -> Self {
         if source.is_connect() {
             Self::Connection(source)
@@ -134,6 +155,21 @@ impl Error {
         Self::Other {
             context: context.into(),
             source: Some(Box::new(source)),
+        }
+    }
+
+    /// Convert a `quick_xml::Error` into the most specific `Error` variant.
+    ///
+    /// `Syntax` and `IllFormed` errors are mapped to [`XmlStructure`](Self::XmlStructure)
+    /// because they indicate a structurally invalid XML document (mismatched tags,
+    /// unclosed elements, …). All other variants (`Io`, `Encoding`, `Escape`,
+    /// `InvalidAttr`, `Namespace`) are mapped to [`Xml`](Self::Xml) via the
+    /// blanket `#[from]` conversion.
+    pub(crate) fn from_quick_xml(error: quick_xml::Error) -> Self {
+        match error {
+            quick_xml::Error::Syntax(s) => Self::XmlStructure(s.to_string()),
+            quick_xml::Error::IllFormed(s) => Self::XmlStructure(s.to_string()),
+            other => Self::Xml(other),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@
 //! ## Basic Setup and Calendar Discovery
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth};
-//! use anyhow::Result;
+//! use fast_dav_rs::{CalDavClient, Depth, Error, Result};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -47,11 +46,11 @@
 //!
 //!     // Discover the current user's principal
 //!     let principal = client.discover_current_user_principal().await?
-//!         .ok_or_else(|| anyhow::anyhow!("No principal found"))?;
+//!         .ok_or_else(|| Error::other("No principal found"))?;
 //!
 //!     // Find calendar home sets
 //!     let homes = client.discover_calendar_home_set(&principal).await?;
-//!     let home = homes.first().ok_or_else(|| anyhow::anyhow!("No calendar home found"))?;
+//!     let home = homes.first().ok_or_else(|| Error::other("No calendar home found"))?;
 //!
 //!     // List all calendars
 //!     let calendars = client.list_calendars(home).await?;
@@ -66,9 +65,8 @@
 //! ## Calendar Operations
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth};
+//! use fast_dav_rs::{CalDavClient, Depth, Result};
 //! use bytes::Bytes;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -104,9 +102,8 @@
 //! ## Event Operations
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth};
+//! use fast_dav_rs::{CalDavClient, Depth, Result};
 //! use bytes::Bytes;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -191,9 +188,8 @@
 //! ## Working with ETags for Safe Operations
 //!
 //! ```no_run
-//! use fast_dav_rs::CalDavClient;
+//! use fast_dav_rs::{CalDavClient, Result};
 //! use bytes::Bytes;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -238,10 +234,9 @@
 //! For processing large collections without loading everything into memory:
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth, detect_encoding};
+//! use fast_dav_rs::{CalDavClient, Depth, Result, detect_encoding};
 //! use fast_dav_rs::caldav::parse_multistatus_stream;
 //! use bytes::Bytes;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -288,10 +283,9 @@
 //! Execute multiple operations concurrently with controlled parallelism:
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth};
+//! use fast_dav_rs::{CalDavClient, Depth, Result};
 //! use bytes::Bytes;
 //! use std::sync::Arc;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -381,8 +375,7 @@
 //! Discover server capabilities and choose appropriate synchronization methods:
 //!
 //! ```no_run
-//! use fast_dav_rs::{CalDavClient, Depth};
-//! use anyhow::Result;
+//! use fast_dav_rs::{CalDavClient, Depth, Error, Result};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -401,12 +394,12 @@
 //!
 //!     // Discover user principal
 //!     let principal = client.discover_current_user_principal().await?
-//!         .ok_or_else(|| anyhow::anyhow!("No principal found"))?;
+//!         .ok_or_else(|| Error::other("No principal found"))?;
 //!     println!("User principal: {}", principal);
 //!
 //!     // Discover calendar homes
 //!     let homes = client.discover_calendar_home_set(&principal).await?;
-//!     let home = homes.first().ok_or_else(|| anyhow::anyhow!("No calendar home found"))?;
+//!     let home = homes.first().ok_or_else(|| Error::other("No calendar home found"))?;
 //!     println!("Calendar home: {}", home);
 //!
 //!     // List calendars with detailed info
@@ -509,8 +502,7 @@
 //! ## CardDAV Addressbook Discovery
 //!
 //! ```no_run
-//! use fast_dav_rs::CardDavClient;
-//! use anyhow::Result;
+//! use fast_dav_rs::{CardDavClient, Error, Result};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -521,10 +513,10 @@
 //!     )?;
 //!
 //!     let principal = client.discover_current_user_principal().await?
-//!         .ok_or_else(|| anyhow::anyhow!("No principal found"))?;
+//!         .ok_or_else(|| Error::other("No principal found"))?;
 //!
 //!     let homes = client.discover_addressbook_home_set(&principal).await?;
-//!     let home = homes.first().ok_or_else(|| anyhow::anyhow!("No addressbook home found"))?;
+//!     let home = homes.first().ok_or_else(|| Error::other("No addressbook home found"))?;
 //!
 //!     let books = client.list_addressbooks(home).await?;
 //!     for book in &books {
@@ -538,9 +530,8 @@
 //! ## CardDAV Contact Operations
 //!
 //! ```no_run
-//! use fast_dav_rs::CardDavClient;
+//! use fast_dav_rs::{CardDavClient, Result};
 //! use bytes::Bytes;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -581,8 +572,7 @@
 //! ## CardDAV Queries and Multiget
 //!
 //! ```no_run
-//! use fast_dav_rs::CardDavClient;
-//! use anyhow::Result;
+//! use fast_dav_rs::{CardDavClient, Result};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -614,9 +604,8 @@
 //! ## CardDAV Streaming Large Responses
 //!
 //! ```no_run
-//! use fast_dav_rs::{CardDavClient, Depth, detect_encoding};
+//! use fast_dav_rs::{CardDavClient, Depth, Result, detect_encoding};
 //! use fast_dav_rs::carddav::parse_multistatus_stream;
-//! use anyhow::Result;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -659,8 +648,7 @@
 //! ## CardDAV Sync Collection
 //!
 //! ```no_run
-//! use fast_dav_rs::CardDavClient;
-//! use anyhow::Result;
+//! use fast_dav_rs::{CardDavClient, Result};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -690,7 +678,10 @@
 pub mod caldav;
 pub mod carddav;
 pub mod common;
+mod error;
 pub mod webdav;
+
+pub use error::{Error, Result};
 
 // Backwards-compatible re-exports
 pub use caldav::streaming::{

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as B64;
 use bytes::Bytes;
@@ -17,6 +16,7 @@ use crate::common::compression::{
 };
 use crate::common::http::{HyperClient, build_hyper_client};
 use crate::webdav::types::{BatchItem, Depth};
+use crate::{Error, Result};
 
 /// Strategy for compressing outgoing request bodies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,7 +77,9 @@ impl WebDavClient {
     pub fn new(base_url: &str, basic_user: Option<&str>, basic_pass: Option<&str>) -> Result<Self> {
         let client = build_hyper_client()?;
 
-        let base: Uri = base_url.parse()?;
+        let base: Uri = base_url
+            .parse()
+            .map_err(|source| Error::invalid_url(base_url, source))?;
         let auth_header = if let (Some(u), Some(p)) = (basic_user, basic_pass) {
             // Build the header value, then zeroize the intermediate strings so
             // plaintext credentials do not linger in freed heap memory.
@@ -141,7 +143,9 @@ impl WebDavClient {
 
     pub fn build_uri(&self, path: &str) -> Result<Uri> {
         if path.starts_with("http://") || path.starts_with("https://") {
-            return Ok(path.parse()?);
+            return path
+                .parse()
+                .map_err(|source| Error::invalid_url(path, source));
         }
 
         let mut parts = self.base.clone().into_parts();
@@ -178,13 +182,17 @@ impl WebDavClient {
         }
 
         let path_and_query = if let Some(q) = query {
-            format!("{}?{}", combined, q).parse()?
+            format!("{}?{}", combined, q)
+                .parse()
+                .map_err(|source| Error::invalid_url(path, source))?
         } else {
-            combined.parse()?
+            combined
+                .parse()
+                .map_err(|source| Error::invalid_url(path, source))?
         };
 
         parts.path_and_query = Some(path_and_query);
-        Ok(Uri::from_parts(parts)?)
+        Uri::from_parts(parts).map_err(|source| Error::invalid_url(path, source))
     }
 
     fn resolve_request_encoding(&self) -> ContentEncoding {
@@ -443,10 +451,12 @@ impl WebDavClient {
                 None => req_builder.body(Full::new(Bytes::new()))?,
             };
 
+            let limit = per_req_timeout.unwrap_or(self.default_timeout);
             let fut = self.client.request(req);
-            let resp = timeout(per_req_timeout.unwrap_or(self.default_timeout), fut)
+            let resp = timeout(limit, fut)
                 .await
-                .map_err(|_| anyhow!("request timed out"))??;
+                .map_err(|_| Error::Timeout { limit })?
+                .map_err(Error::from_client)?;
 
             let should_retry =
                 self.handle_request_compression_outcome(attempted_encoding, resp.status());
@@ -517,10 +527,12 @@ impl WebDavClient {
                 None => req_builder.body(Full::new(Bytes::new()))?,
             };
 
+            let limit = per_req_timeout.unwrap_or(self.default_timeout);
             let fut = self.client.request(req);
-            let resp = timeout(per_req_timeout.unwrap_or(self.default_timeout), fut)
+            let resp = timeout(limit, fut)
                 .await
-                .map_err(|_| anyhow!("request timed out"))??;
+                .map_err(|_| Error::Timeout { limit })?
+                .map_err(Error::from_client)?;
 
             let should_retry =
                 self.handle_request_compression_outcome(attempted_encoding, resp.status());

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -46,23 +46,28 @@ const PROBE_BODY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 pub(crate) fn if_match_header_value(etag: &str) -> Result<header::HeaderValue> {
     let etag = etag.trim();
     if etag.is_empty() {
-        return Err(anyhow!("ETag cannot be empty"));
+        return Err(Error::InvalidInput("ETag cannot be empty".to_owned()));
     }
 
     let value = if etag == "*" || is_valid_entity_tag(etag) {
         etag.to_owned()
     } else {
         if etag.starts_with('"') || etag.starts_with("W/") || etag.contains('"') {
-            return Err(anyhow!("ETag has an invalid entity-tag format"));
+            return Err(Error::InvalidInput(
+                "ETag has an invalid entity-tag format".to_owned(),
+            ));
         }
         if !etag.bytes().all(is_etag_character) {
-            return Err(anyhow!("ETag contains invalid entity-tag characters"));
+            return Err(Error::InvalidInput(
+                "ETag contains invalid entity-tag characters".to_owned(),
+            ));
         }
         format!("\"{etag}\"")
     };
 
-    header::HeaderValue::from_str(&value)
-        .map_err(|err| anyhow!("ETag cannot be used as an If-Match header: {err}"))
+    header::HeaderValue::from_str(&value).map_err(|err| {
+        Error::InvalidInput(format!("ETag cannot be used as an If-Match header: {err}"))
+    })
 }
 
 fn is_valid_entity_tag(etag: &str) -> bool {

--- a/src/webdav/streaming.rs
+++ b/src/webdav/streaming.rs
@@ -1,5 +1,5 @@
 use crate::webdav::types::DavItemCommon;
-use anyhow::{Result, anyhow};
+use crate::{Error, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommonElement {
@@ -106,14 +106,14 @@ impl CommonParser {
         let element = common_element_from_bytes(raw);
         match self.stack.pop() {
             Some(popped) if popped == element => Ok(()),
-            Some(popped) => Err(anyhow!(
-                "XML structure error: closing tag </{}> does not match the last opened element (expected {popped:?}, found {element:?})",
+            Some(popped) => Err(Error::XmlStructure(format!(
+                "closing tag </{}> does not match the last opened element (expected {popped:?}, found {element:?})",
                 String::from_utf8_lossy(raw)
-            )),
-            None => Err(anyhow!(
-                "XML structure error: closing tag </{}> without a matching opening tag",
+            ))),
+            None => Err(Error::XmlStructure(format!(
+                "closing tag </{}> without a matching opening tag",
                 String::from_utf8_lossy(raw)
-            )),
+            ))),
         }
     }
 

--- a/src/webdav/types.rs
+++ b/src/webdav/types.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Result;
 
 /// WebDAV Depth
 #[derive(Copy, Clone)]

--- a/src/webdav/xml.rs
+++ b/src/webdav/xml.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use crate::{Error, Result};
 
 pub fn escape_xml(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
@@ -28,16 +28,18 @@ pub fn escape_xml(input: &str) -> String {
 /// `[A-Za-z0-9-]`.
 pub(crate) fn validate_component_name(name: &str) -> Result<()> {
     if name.is_empty() {
-        return Err(anyhow!("component name must not be empty"));
+        return Err(Error::InvalidInput(
+            "component name must not be empty".to_owned(),
+        ));
     }
     if let Some(bad) = name
         .chars()
         .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))
     {
-        return Err(anyhow!(
+        return Err(Error::InvalidInput(format!(
             "component name {name:?} contains invalid character {bad:?}: \
              only ASCII letters, digits and '-' are allowed (e.g. VEVENT, X-CUSTOM)"
-        ));
+        )));
     }
     Ok(())
 }
@@ -61,10 +63,10 @@ pub(crate) fn validate_utc_datetime(value: &str) -> Result<()> {
         && bytes[9..15].iter().all(u8::is_ascii_digit)
         && bytes[15] == b'Z';
     if !structurally_valid {
-        return Err(anyhow!(
+        return Err(Error::InvalidInput(format!(
             "invalid UTC date-time {value:?}: expected iCalendar format \
              YYYYMMDDTHHMMSSZ (e.g. 20240101T000000Z)"
-        ));
+        )));
     }
     Ok(())
 }

--- a/src/webdav/xml.rs
+++ b/src/webdav/xml.rs
@@ -26,18 +26,18 @@ pub fn escape_xml(input: &str) -> String {
 ///
 /// Returns an error when `name` is empty or contains a character outside
 /// `[A-Za-z0-9-]`.
-pub(crate) fn validate_component_name(name: &str) -> Result<()> {
+pub(crate) fn validate_component_name(name: &str, context: &str) -> Result<()> {
     if name.is_empty() {
-        return Err(Error::InvalidInput(
-            "component name must not be empty".to_owned(),
-        ));
+        return Err(Error::InvalidInput(format!(
+            "{context}: component name must not be empty"
+        )));
     }
     if let Some(bad) = name
         .chars()
         .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))
     {
         return Err(Error::InvalidInput(format!(
-            "component name {name:?} contains invalid character {bad:?}: \
+            "{context}: component name {name:?} contains invalid character {bad:?}: \
              only ASCII letters, digits and '-' are allowed (e.g. VEVENT, X-CUSTOM)"
         )));
     }
@@ -55,7 +55,7 @@ pub(crate) fn validate_component_name(name: &str) -> Result<()> {
 /// # Errors
 ///
 /// Returns an error when `value` does not match `YYYYMMDDTHHMMSSZ`.
-pub(crate) fn validate_utc_datetime(value: &str) -> Result<()> {
+pub(crate) fn validate_utc_datetime(value: &str, context: &str) -> Result<()> {
     let bytes = value.as_bytes();
     let structurally_valid = bytes.len() == 16
         && bytes[..8].iter().all(u8::is_ascii_digit)
@@ -64,7 +64,7 @@ pub(crate) fn validate_utc_datetime(value: &str) -> Result<()> {
         && bytes[15] == b'Z';
     if !structurally_valid {
         return Err(Error::InvalidInput(format!(
-            "invalid UTC date-time {value:?}: expected iCalendar format \
+            "{context}: invalid UTC date-time {value:?}: expected iCalendar format \
              YYYYMMDDTHHMMSSZ (e.g. 20240101T000000Z)"
         )));
     }

--- a/tests/e2e/caldav/sync/comparison_tests.rs
+++ b/tests/e2e/caldav/sync/comparison_tests.rs
@@ -27,7 +27,7 @@ fn create_test_client() -> CalDavClient {
 async fn traditional_sync_method(
     client: &CalDavClient,
     calendar_paths: &[String],
-) -> anyhow::Result<HashMap<String, String>> {
+) -> fast_dav_rs::Result<HashMap<String, String>> {
     // Step 1: Fetch ctags for all calendars in parallel
     let mut ctag_futures = Vec::new();
     for calendar_path in calendar_paths {
@@ -107,7 +107,7 @@ async fn webdav_sync_method(
     client: &CalDavClient,
     calendar_path: &str,
     sync_token: Option<&str>,
-) -> anyhow::Result<(Option<String>, Vec<String>)> {
+) -> fast_dav_rs::Result<(Option<String>, Vec<String>)> {
     // Use the sync_collection method implemented in the client
     let sync_response = client
         .sync_collection(calendar_path, sync_token, Some(100), true)

--- a/tests/unit/caldav/streaming_tests.rs
+++ b/tests/unit/caldav/streaming_tests.rs
@@ -55,10 +55,10 @@ async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::D
 
     server_task
         .await
-        .map_err(|error| Error::other(error.to_string()))??;
+        .map_err(|error| Error::with_source("server task failed", error))??;
     conn_task
         .await
-        .map_err(|error| Error::other(error.to_string()))??;
+        .map_err(|error| Error::with_source("connection task failed", error))??;
 
     Ok(parsed)
 }

--- a/tests/unit/caldav/streaming_tests.rs
+++ b/tests/unit/caldav/streaming_tests.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use fast_dav_rs::streaming::*;
+use fast_dav_rs::{Error, Result};
 use http_body_util::Full;
 use hyper::Request;
 use hyper::client::conn::http1;
@@ -53,8 +53,12 @@ async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::D
     let encodings = fast_dav_rs::detect_encodings(resp.headers());
     let parsed = parse_multistatus_stream(resp.into_body(), &encodings).await?;
 
-    server_task.await??;
-    conn_task.await??;
+    server_task
+        .await
+        .map_err(|error| Error::other(error.to_string()))??;
+    conn_task
+        .await
+        .map_err(|error| Error::other(error.to_string()))??;
 
     Ok(parsed)
 }
@@ -147,7 +151,7 @@ fn test_multistatus_visit_error_propagates() {
 </D:multistatus>
 "#;
 
-    let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(anyhow!("boom")));
+    let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(Error::other("boom")));
 
     assert!(err.is_err(), "expected visitor error to propagate");
 }

--- a/tests/unit/carddav/streaming_tests.rs
+++ b/tests/unit/carddav/streaming_tests.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use fast_dav_rs::carddav::streaming::*;
+use fast_dav_rs::{Error, Result};
 use http_body_util::Full;
 use hyper::Request;
 use hyper::client::conn::http1;
@@ -53,8 +53,12 @@ async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::c
     let encodings = fast_dav_rs::detect_encodings(resp.headers());
     let parsed = parse_multistatus_stream(resp.into_body(), &encodings).await?;
 
-    server_task.await??;
-    conn_task.await??;
+    server_task
+        .await
+        .map_err(|error| Error::other(error.to_string()))??;
+    conn_task
+        .await
+        .map_err(|error| Error::other(error.to_string()))??;
 
     Ok(parsed)
 }
@@ -147,7 +151,7 @@ fn test_multistatus_visit_error_propagates() {
 </D:multistatus>
 "#;
 
-    let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(anyhow!("boom")));
+    let err = parse_multistatus_bytes_visit(xml.as_bytes(), |_item| Err(Error::other("boom")));
 
     assert!(err.is_err(), "expected visitor error to propagate");
 }

--- a/tests/unit/carddav/streaming_tests.rs
+++ b/tests/unit/carddav/streaming_tests.rs
@@ -55,10 +55,10 @@ async fn parse_streaming_xml(xml: &str) -> Result<ParseResult<Vec<fast_dav_rs::c
 
     server_task
         .await
-        .map_err(|error| Error::other(error.to_string()))??;
+        .map_err(|error| Error::with_source("server task failed", error))??;
     conn_task
         .await
-        .map_err(|error| Error::other(error.to_string()))??;
+        .map_err(|error| Error::with_source("connection task failed", error))??;
 
     Ok(parsed)
 }

--- a/tests/unit/common/error_tests.rs
+++ b/tests/unit/common/error_tests.rs
@@ -1,0 +1,70 @@
+use fast_dav_rs::{CalDavClient, Error, Result};
+use hyper::StatusCode;
+use std::time::Duration;
+
+#[test]
+fn invalid_url_preserves_the_offending_value() {
+    let error = CalDavClient::new("not a valid url", None, None)
+        .err()
+        .expect("an invalid URL should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidUrl { ref url, .. } if url == "not a valid url"
+    ));
+}
+
+#[tokio::test]
+async fn invalid_etag_is_a_typed_input_error() {
+    let client = CalDavClient::new("http://localhost/", None, None).unwrap();
+    let error = client
+        .put_if_match("event.ics", bytes::Bytes::new(), "")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::InvalidInput(ref message) if message == "ETag cannot be empty"
+    ));
+}
+
+#[tokio::test]
+async fn invalid_calendar_component_is_a_typed_input_error() {
+    let client = CalDavClient::new("http://localhost/", None, None).unwrap();
+    let error = client
+        .calendar_query_timerange("calendar/", "VEVENT/INVALID", None, None, false)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::InvalidInput(ref message)
+            if message.starts_with("invalid calendar-query component:")
+    ));
+}
+
+#[test]
+fn public_error_variants_expose_retry_relevant_context() {
+    let status_error = Error::UnexpectedStatus {
+        operation: "PROPFIND calendars".to_owned(),
+        status: StatusCode::FORBIDDEN,
+    };
+    assert_eq!(
+        status_error.to_string(),
+        "PROPFIND calendars failed with 403 Forbidden"
+    );
+
+    let timeout_error = Error::Timeout {
+        limit: Duration::from_secs(20),
+    };
+    assert!(timeout_error.to_string().contains("20s"));
+}
+
+#[test]
+fn standard_error_conversions_remain_typed() {
+    let io_error: Error = std::io::Error::other("broken pipe").into();
+    assert!(matches!(io_error, Error::Io(_)));
+
+    let result: Result<()> = Err(Error::other("application callback failed"));
+    assert!(matches!(result, Err(Error::Other(_))));
+}

--- a/tests/unit/common/error_tests.rs
+++ b/tests/unit/common/error_tests.rs
@@ -1,6 +1,5 @@
 use fast_dav_rs::{CalDavClient, Error, Result};
 use hyper::StatusCode;
-use std::error::Error as StdError;
 use std::time::Duration;
 
 #[test]
@@ -142,11 +141,12 @@ fn other_with_source_preserves_chain() {
     ));
 
     assert!(
-        StdError::source(&error).is_some(),
+        error.source().is_some(),
         "source() must return the inner error"
     );
     assert!(
-        StdError::source(&error)
+        error
+            .source()
             .unwrap()
             .to_string()
             .contains("inner failure"),
@@ -161,5 +161,5 @@ fn other_without_source_has_no_chain() {
         &error,
         Error::Other { context, source: None } if context == "standalone message"
     ));
-    assert!(StdError::source(&error).is_none());
+    assert!(error.source().is_none());
 }

--- a/tests/unit/common/error_tests.rs
+++ b/tests/unit/common/error_tests.rs
@@ -11,7 +11,7 @@ fn invalid_url_preserves_the_offending_value() {
 
     assert!(matches!(
         error,
-        Error::InvalidUrl { ref url, .. } if url == "not a valid url"
+        Error::InvalidUrl { url, .. } if url == "not a valid url"
     ));
 }
 
@@ -25,7 +25,7 @@ async fn invalid_etag_is_a_typed_input_error() {
 
     assert!(matches!(
         error,
-        Error::InvalidInput(ref message) if message == "ETag cannot be empty"
+        Error::InvalidInput(message) if message == "ETag cannot be empty"
     ));
 }
 
@@ -39,7 +39,7 @@ async fn invalid_calendar_component_is_a_typed_input_error() {
 
     assert!(matches!(
         error,
-        Error::InvalidInput(ref message)
+        Error::InvalidInput(message)
             if message.starts_with("invalid calendar-query component:")
     ));
 }

--- a/tests/unit/common/error_tests.rs
+++ b/tests/unit/common/error_tests.rs
@@ -67,7 +67,7 @@ fn standard_error_conversions_remain_typed() {
 
     let result: Result<()> = Err(Error::other("application callback failed"));
     assert!(
-        matches!(result, Err(Error::Other { context, source: None }) if context == "application callback failed")
+        matches!(result, Err(Error::Other { context, .. }) if context == "application callback failed")
     );
 }
 
@@ -159,7 +159,7 @@ fn other_without_source_has_no_chain() {
     let error = Error::other("standalone message");
     assert!(matches!(
         &error,
-        Error::Other { context, source: None } if context == "standalone message"
+        Error::Other { context, .. } if context == "standalone message"
     ));
     assert!(error.source().is_none());
 }

--- a/tests/unit/common/error_tests.rs
+++ b/tests/unit/common/error_tests.rs
@@ -1,5 +1,6 @@
 use fast_dav_rs::{CalDavClient, Error, Result};
 use hyper::StatusCode;
+use std::error::Error as StdError;
 use std::time::Duration;
 
 #[test]
@@ -66,5 +67,99 @@ fn standard_error_conversions_remain_typed() {
     assert!(matches!(io_error, Error::Io(_)));
 
     let result: Result<()> = Err(Error::other("application callback failed"));
-    assert!(matches!(result, Err(Error::Other(_))));
+    assert!(
+        matches!(result, Err(Error::Other { context, source: None }) if context == "application callback failed")
+    );
+}
+
+#[test]
+fn from_invalid_header_value() {
+    let error: Error = hyper::header::HeaderValue::from_str("invalid\n")
+        .unwrap_err()
+        .into();
+    assert!(matches!(error, Error::InvalidHeader(_)));
+}
+
+#[test]
+fn from_invalid_method() {
+    let error: Error = hyper::http::Method::from_bytes(b"INVALID METHOD")
+        .unwrap_err()
+        .into();
+    assert!(matches!(error, Error::InvalidMethod(_)));
+}
+
+#[test]
+fn from_http_error() {
+    let uri_result: std::result::Result<hyper::http::uri::Uri, _> = "bad uri with spaces".parse();
+    let uri_err = uri_result.unwrap_err();
+    let http_err: hyper::http::Error = uri_err.into();
+    let error: Error = http_err.into();
+    assert!(matches!(error, Error::Http(_)));
+}
+
+// NOTE: hyper::Error (the Hyper variant) cannot be unit-tested in isolation
+// because all its constructors are pub(super). It is exercised by the
+// integration and streaming tests that perform real HTTP I/O.
+
+#[test]
+fn from_quick_xml_error() {
+    let escape_error = quick_xml::escape::EscapeError::UnrecognizedEntity(0..3, "foo".into());
+    let xml_error: quick_xml::Error = escape_error.into();
+    let error: Error = xml_error.into();
+    assert!(matches!(error, Error::Xml(_)));
+}
+
+#[test]
+fn from_xml_attribute_error() {
+    let attr_error = quick_xml::events::attributes::AttrError::ExpectedEq(0);
+    let error: Error = attr_error.into();
+    assert!(matches!(error, Error::XmlAttribute(_)));
+}
+
+#[test]
+fn from_xml_escape_error() {
+    let escape_error = quick_xml::escape::EscapeError::UnrecognizedEntity(0..3, "foo".into());
+    let error: Error = escape_error.into();
+    assert!(matches!(error, Error::XmlEscape(_)));
+}
+
+#[test]
+fn from_utf8_error() {
+    #![allow(invalid_from_utf8)]
+    let utf8_error = std::str::from_utf8(&[0xFF, 0xFE, 0xFD]).unwrap_err();
+    let error: Error = utf8_error.into();
+    assert!(matches!(error, Error::Utf8(_)));
+}
+
+#[test]
+fn other_with_source_preserves_chain() {
+    let source = std::io::Error::other("inner failure");
+    let error = Error::with_source("outer context", source);
+
+    assert!(matches!(
+        &error,
+        Error::Other { context, source: Some(_) } if context == "outer context"
+    ));
+
+    assert!(
+        StdError::source(&error).is_some(),
+        "source() must return the inner error"
+    );
+    assert!(
+        StdError::source(&error)
+            .unwrap()
+            .to_string()
+            .contains("inner failure"),
+        "source chain must preserve the inner message"
+    );
+}
+
+#[test]
+fn other_without_source_has_no_chain() {
+    let error = Error::other("standalone message");
+    assert!(matches!(
+        &error,
+        Error::Other { context, source: None } if context == "standalone message"
+    ));
+    assert!(StdError::source(&error).is_none());
 }

--- a/tests/unit/common/mod.rs
+++ b/tests/unit/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod compression_integration_tests;
 pub mod compression_tests;
+pub mod error_tests;


### PR DESCRIPTION
### Typed errors with thiserror
Replace anyhow throughout the public API with a structured, #[non_exhaustive] Error enum, allowing callers to match on specific failure modes instead of string-matching error messages.
#### What's included
- Error enum (src/error.rs, 187 lines) with variants for:
  - InvalidUrl, InvalidInput, InvalidHeader, InvalidMethod
  - Http, Hyper, Connection, Transport — HTTP-layer errors with hyper source chaining
  - UnexpectedStatus { operation, status } — DAV-level status mismatches
  - Timeout { limit }, Xml, XmlStructure, XmlEscape, XmlAttribute
  - Io, Utf8, Other (catch-all for user callbacks)
- Result<T> alias now resolves to Result<T, Error> instead of anyhow::Result
- Hyper error categorization — refined Connection vs Transport splitting for better diagnostics
- Source chaining via #[source] on all wrapping variants
- Replaced all anyhow::anyhow!() / .context() calls across caldav, carddav, webdav, common
#### Why
anyhow is great for applications but poor for libraries — callers can't programmatically react to specific errors (e.g. retry on Timeout, surface InvalidInput as a 4xx). Typed errors give downstream code a stable, matchable contract while preserving full causal chains through .source().