### PR TITLE
Feat/client builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
@@ -233,7 +239,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-compression",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -242,8 +248,13 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "quick-xml",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "tokio",
  "tokio-util",
+ "tower-service",
+ "webpki-roots 0.26.11",
  "zeroize",
 ]
 
@@ -487,7 +498,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -496,13 +507,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -543,6 +557,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -663,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +782,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1097,6 +1132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ include = ["Cargo.toml", "LICENSE", "/README.md", "src/**/*.rs"]
 [dependencies]
 anyhow = "1"
 base64 = "0.23"
+rustls = "0.23"
+rustls-pemfile = "2"
+rustls-native-certs = "0.8"
+webpki-roots = "0.26"
+tower-service = "0.3"
 bytes = "1"
 futures = "0.3"
 hyper = { version = "1", features = ["client", "http1", "http2"] }
@@ -20,7 +25,7 @@ quick-xml = { version = "0.41.0", features = ["async-tokio"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-util = "0.7"
 async-compression = { version = "0.4", features = ["tokio", "brotli", "gzip", "zstd"] }
-hyper-util = { version = "0.1", features = ["client", "http1", "http2", "tokio"] }
+hyper-util = { version = "0.1", features = ["client", "http1", "http2", "tokio", "client-proxy"] }
 http-body-util = "0.1"
 zeroize = "1"
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,57 @@ so you can override the default timeout for specific requests.
 `propfind_many` and `report_many` accept a `max_concurrency` parameter to bound the number of in-flight
 requests while preserving input order in the result list.
 
+## Advanced Configuration
+
+For production use, use the builder pattern to configure auth, timeouts,
+connection pool, TLS, proxy, and more:
+
+### Basic auth + timeout + pool
+
+```rust
+use fast_dav_rs::CalDavClient;
+use std::time::Duration;
+
+let client = CalDavClient::builder("https://cal.example.com/dav/")
+    .basic_auth("user", "pass")
+    .timeout(Duration::from_secs(30))
+    .user_agent("MyApp/1.0")
+    .pool_max_idle_per_host(10)
+    .build()?;
+```
+
+### Bearer/OAuth 2.0 token
+
+```rust
+let client = CalDavClient::builder("https://cal.example.com/dav/")
+    .bearer_token("ya29.token...")
+    .build()?;
+```
+
+### Proxy + custom CA for debugging
+
+Route traffic through a debugging proxy (Proxyman/Charles/mitmproxy)
+and trust its MITM CA — works on Android non-rooted and iOS/macOS alike:
+
+```rust
+let client = CalDavClient::builder("https://cal.example.com/dav/")
+    .basic_auth("user", "pass")
+    .proxy("http://127.0.0.1:9090")
+    .proxy_basic_auth("proxyuser", "proxypass")
+    .extra_root_certs_pem(vec![std::fs::read("/path/proxyman-ca.pem")?])
+    .build()?;
+```
+
+### Force HTTP/1.1
+
+For servers or proxies that misbehave with HTTP/2:
+
+```rust
+let client = CalDavClient::builder("https://cal.example.com/dav/")
+    .force_http1(true)
+    .build()?;
+```
+
 ## Security
 
 Basic credentials are sent as an `Authorization: Basic` header on every request. Base64 is an

--- a/src/caldav/builder.rs
+++ b/src/caldav/builder.rs
@@ -42,12 +42,25 @@ impl CalDavClientBuilder {
     }
 
     /// Send **Basic** credentials with every request. Default: no auth.
+    ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on
+    /// **every** request. Base64 is an encoding, not encryption: over plain
+    /// `http://` the credentials travel effectively in cleartext. Always use
+    /// `https://` outside isolated test environments.
     pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
         self.inner = self.inner.basic_auth(user, pass);
         self
     }
 
     /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    ///
+    /// # Security
+    ///
+    /// The bearer token is sent as an `Authorization: Bearer` header on
+    /// **every** request. Over plain `http://` the token travels in
+    /// cleartext. Always use `https://` outside isolated test environments.
     pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
         self.inner = self.inner.bearer_token(token);
         self

--- a/src/caldav/builder.rs
+++ b/src/caldav/builder.rs
@@ -1,151 +1,33 @@
 //! Builder for [`CalDavClient`] — a thin wrapper over
 //! [`WebDavClientBuilder`] with the same option set.
-
-use std::time::Duration;
-
-use hyper::Uri;
+//!
+//! See [`CalDavClient::builder`](crate::caldav::client::CalDavClient::builder)
+//! for usage.
 
 use crate::caldav::client::CalDavClient;
-use crate::webdav::builder::WebDavClientBuilder;
-use crate::webdav::client::RequestCompressionMode;
+use crate::impl_dav_builder;
 
-/// Builder for [`CalDavClient`].
-///
-/// Created with [`CalDavClient::builder`]. Delegates every option to
-/// [`WebDavClientBuilder`]; only the base URL is required.
-///
-/// # Example
-///
-/// ```no_run
-/// use fast_dav_rs::CalDavClient;
-/// use fast_dav_rs::webdav::RequestCompressionMode;
-/// use std::time::Duration;
-///
-/// let client = CalDavClient::builder("https://cal.example.com/dav/user01/")
-///     .basic_auth("user01", "secret")
-///     .timeout(Duration::from_secs(10))
-///     .pool_max_idle_per_host(8)
-///     .request_compression(RequestCompressionMode::Auto)
-///     .build()?;
-/// # Ok::<(), anyhow::Error>(())
-/// ```
-#[derive(Debug)]
-pub struct CalDavClientBuilder {
-    inner: WebDavClientBuilder,
-}
-
-impl CalDavClientBuilder {
-    pub(crate) fn new(base_url: impl Into<String>) -> Self {
-        Self {
-            inner: WebDavClientBuilder::new(base_url),
-        }
-    }
-
-    /// Send **Basic** credentials with every request. Default: no auth.
+impl_dav_builder! {
+    /// Builder for [`CalDavClient`].
     ///
-    /// # Security
+    /// Created with [`CalDavClient::builder`]. Delegates every option to
+    /// [`WebDavClientBuilder`]; only the base URL is required.
     ///
-    /// Basic credentials are sent as an `Authorization: Basic` header on
-    /// **every** request. Base64 is an encoding, not encryption: over plain
-    /// `http://` the credentials travel effectively in cleartext. Always use
-    /// `https://` outside isolated test environments.
-    pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
-        self.inner = self.inner.basic_auth(user, pass);
-        self
-    }
-
-    /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    /// # Example
     ///
-    /// # Security
+    /// ```no_run
+    /// use fast_dav_rs::CalDavClient;
+    /// use fast_dav_rs::webdav::RequestCompressionMode;
+    /// use std::time::Duration;
     ///
-    /// The bearer token is sent as an `Authorization: Bearer` header on
-    /// **every** request. Over plain `http://` the token travels in
-    /// cleartext. Always use `https://` outside isolated test environments.
-    pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
-        self.inner = self.inner.bearer_token(token);
-        self
-    }
-
-    /// Set the default per-request timeout. Default: **20 seconds**.
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.timeout(timeout);
-        self
-    }
-
-    /// Set the TCP connect timeout applied to the connector. Default: **none**.
-    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.connect_timeout(timeout);
-        self
-    }
-
-    /// Set the `User-Agent` header sent on every request. Default: **none**.
-    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
-        self.inner = self.inner.user_agent(ua);
-        self
-    }
-
-    /// Force HTTP/1.1 only (disable HTTP/2 negotiation). Default: **false**.
-    pub fn force_http1(mut self, force: bool) -> Self {
-        self.inner = self.inner.force_http1(force);
-        self
-    }
-
-    /// Cap the number of idle pooled connections kept alive per host.
-    /// Default: **32**.
-    pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
-        self.inner = self.inner.pool_max_idle_per_host(max_idle);
-        self
-    }
-
-    /// Set the idle connection timeout for the pool. Default: **unbounded**.
-    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.pool_idle_timeout(timeout);
-        self
-    }
-
-    /// Choose the request-body compression strategy. Default:
-    /// [`RequestCompressionMode::Auto`].
-    pub fn request_compression(mut self, mode: RequestCompressionMode) -> Self {
-        self.inner = self.inner.request_compression(mode);
-        self
-    }
-
-    /// Route all requests through this proxy (e.g. `http://127.0.0.1:9090`).
-    /// HTTPS is tunneled via HTTP CONNECT. Default: **no proxy**.
-    pub fn proxy(mut self, proxy: impl Into<Uri>) -> Self {
-        self.inner = self.inner.proxy(proxy);
-        self
-    }
-
-    /// Set Basic credentials for the proxy. Default: **no proxy auth**.
-    pub fn proxy_basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
-        self.inner = self.inner.proxy_basic_auth(user, pass);
-        self
-    }
-
-    /// Add additional PEM-encoded trust roots on top of the native/webpki
-    /// roots — e.g. a Proxyman/Charles/mitmproxy root CA. Default: **empty**.
-    pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
-        self.inner = self.inner.extra_root_certs_pem(certs);
-        self
-    }
-
-    /// Accept any server certificate without verification. **Testing/debug
-    /// only — never enable in production.** Default: **false**.
-    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
-        self.inner = self.inner.danger_accept_invalid_certs(accept);
-        self
-    }
-
-    /// Validate the configuration and construct the [`CalDavClient`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the base URL is not a valid URI, if credentials
-    /// are provided but cannot be encoded, if the proxy URI is invalid,
-    /// if `timeout` or `pool_max_idle_per_host` is zero, or if PEM
-    /// certificates cannot be parsed.
-    pub fn build(self) -> anyhow::Result<CalDavClient> {
-        Ok(CalDavClient::from_webdav(self.inner.build()?))
-    }
+    /// let client = CalDavClient::builder("https://cal.example.com/dav/user01/")
+    ///     .basic_auth("user01", "secret")
+    ///     .timeout(Duration::from_secs(10))
+    ///     .pool_max_idle_per_host(8)
+    ///     .request_compression(RequestCompressionMode::Auto)
+    ///     .build()?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub struct CalDavClientBuilder;
+    client = CalDavClient;
 }

--- a/src/caldav/builder.rs
+++ b/src/caldav/builder.rs
@@ -1,0 +1,138 @@
+//! Builder for [`CalDavClient`] — a thin wrapper over
+//! [`WebDavClientBuilder`] with the same option set.
+
+use std::time::Duration;
+
+use hyper::Uri;
+
+use crate::caldav::client::CalDavClient;
+use crate::webdav::builder::WebDavClientBuilder;
+use crate::webdav::client::RequestCompressionMode;
+
+/// Builder for [`CalDavClient`].
+///
+/// Created with [`CalDavClient::builder`]. Delegates every option to
+/// [`WebDavClientBuilder`]; only the base URL is required.
+///
+/// # Example
+///
+/// ```no_run
+/// use fast_dav_rs::CalDavClient;
+/// use fast_dav_rs::webdav::RequestCompressionMode;
+/// use std::time::Duration;
+///
+/// let client = CalDavClient::builder("https://cal.example.com/dav/user01/")
+///     .basic_auth("user01", "secret")
+///     .timeout(Duration::from_secs(10))
+///     .pool_max_idle_per_host(8)
+///     .request_compression(RequestCompressionMode::Auto)
+///     .build()?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct CalDavClientBuilder {
+    inner: WebDavClientBuilder,
+}
+
+impl CalDavClientBuilder {
+    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            inner: WebDavClientBuilder::new(base_url),
+        }
+    }
+
+    /// Send **Basic** credentials with every request. Default: no auth.
+    pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.inner = self.inner.basic_auth(user, pass);
+        self
+    }
+
+    /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.inner = self.inner.bearer_token(token);
+        self
+    }
+
+    /// Set the default per-request timeout. Default: **20 seconds**.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
+    /// Set the TCP connect timeout applied to the connector. Default: **none**.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.connect_timeout(timeout);
+        self
+    }
+
+    /// Set the `User-Agent` header sent on every request. Default: **none**.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.inner = self.inner.user_agent(ua);
+        self
+    }
+
+    /// Force HTTP/1.1 only (disable HTTP/2 negotiation). Default: **false**.
+    pub fn force_http1(mut self, force: bool) -> Self {
+        self.inner = self.inner.force_http1(force);
+        self
+    }
+
+    /// Cap the number of idle pooled connections kept alive per host.
+    /// Default: **32**.
+    pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
+        self.inner = self.inner.pool_max_idle_per_host(max_idle);
+        self
+    }
+
+    /// Set the idle connection timeout for the pool. Default: **unbounded**.
+    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.pool_idle_timeout(timeout);
+        self
+    }
+
+    /// Choose the request-body compression strategy. Default:
+    /// [`RequestCompressionMode::Auto`].
+    pub fn request_compression(mut self, mode: RequestCompressionMode) -> Self {
+        self.inner = self.inner.request_compression(mode);
+        self
+    }
+
+    /// Route all requests through this proxy (e.g. `http://127.0.0.1:9090`).
+    /// HTTPS is tunneled via HTTP CONNECT. Default: **no proxy**.
+    pub fn proxy(mut self, proxy: impl Into<Uri>) -> Self {
+        self.inner = self.inner.proxy(proxy);
+        self
+    }
+
+    /// Set Basic credentials for the proxy. Default: **no proxy auth**.
+    pub fn proxy_basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.inner = self.inner.proxy_basic_auth(user, pass);
+        self
+    }
+
+    /// Add additional PEM-encoded trust roots on top of the native/webpki
+    /// roots — e.g. a Proxyman/Charles/mitmproxy root CA. Default: **empty**.
+    pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
+        self.inner = self.inner.extra_root_certs_pem(certs);
+        self
+    }
+
+    /// Accept any server certificate without verification. **Testing/debug
+    /// only — never enable in production.** Default: **false**.
+    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
+        self.inner = self.inner.danger_accept_invalid_certs(accept);
+        self
+    }
+
+    /// Validate the configuration and construct the [`CalDavClient`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the base URL is not a valid URI, if credentials
+    /// are provided but cannot be encoded, if the proxy URI is invalid,
+    /// if `timeout` or `pool_max_idle_per_host` is zero, or if PEM
+    /// certificates cannot be parsed.
+    pub fn build(self) -> anyhow::Result<CalDavClient> {
+        Ok(CalDavClient::from_webdav(self.inner.build()?))
+    }
+}

--- a/src/caldav/client.rs
+++ b/src/caldav/client.rs
@@ -5,6 +5,7 @@ use hyper::{HeaderMap, Method, Response, Uri, header};
 use std::sync::Arc;
 use tokio::time::Duration;
 
+use crate::caldav::builder::CalDavClientBuilder;
 use crate::caldav::streaming::parse_multistatus_bytes;
 use crate::caldav::types::{
     BatchItem, CalendarInfo, CalendarObject, DavItem, Depth, SyncItem, SyncResponse,
@@ -74,9 +75,37 @@ impl CalDavClient {
     /// # }
     /// ```
     pub fn new(base_url: &str, basic_user: Option<&str>, basic_pass: Option<&str>) -> Result<Self> {
-        Ok(Self {
-            webdav: WebDavClient::new(base_url, basic_user, basic_pass)?,
-        })
+        let mut builder = Self::builder(base_url);
+        if let (Some(u), Some(p)) = (basic_user, basic_pass) {
+            builder = builder.basic_auth(u, p);
+        }
+        builder.build()
+    }
+
+    /// Create a builder for configuring the client before construction.
+    ///
+    /// Only the base URL is required; every other option has a sensible
+    /// default documented on [`CalDavClientBuilder`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fast_dav_rs::CalDavClient;
+    /// use std::time::Duration;
+    ///
+    /// let client = CalDavClient::builder("https://cal.example.com/dav/")
+    ///     .basic_auth("user", "pass")
+    ///     .timeout(Duration::from_secs(30))
+    ///     .build()?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn builder(base_url: impl Into<String>) -> CalDavClientBuilder {
+        CalDavClientBuilder::new(base_url)
+    }
+
+    /// Wrap a [`WebDavClient`] into a [`CalDavClient`].
+    pub(crate) fn from_webdav(webdav: WebDavClient) -> Self {
+        Self { webdav }
     }
 
     /// Configure request compression for this client.
@@ -91,7 +120,7 @@ impl CalDavClient {
     /// use fast_dav_rs::{CalDavClient, ContentEncoding};
     ///
     /// # fn example() -> anyhow::Result<()> {
-    /// let mut client = CalDavClient::new(
+    /// let client = CalDavClient::new(
     ///     "https://cal.example.com/dav/user01/",
     ///     Some("user01"),
     ///     Some("secret"),
@@ -100,22 +129,22 @@ impl CalDavClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_request_compression(&mut self, encoding: ContentEncoding) {
+    pub fn set_request_compression(&self, encoding: ContentEncoding) {
         self.webdav.set_request_compression(encoding);
     }
 
     /// Configure the request compression strategy.
-    pub fn set_request_compression_mode(&mut self, mode: RequestCompressionMode) {
+    pub fn set_request_compression_mode(&self, mode: RequestCompressionMode) {
         self.webdav.set_request_compression_mode(mode);
     }
 
     /// Enable adaptive request compression (default behaviour).
-    pub fn set_request_compression_auto(&mut self) {
+    pub fn set_request_compression_auto(&self) {
         self.webdav.set_request_compression_auto();
     }
 
     /// Disable request compression entirely.
-    pub fn disable_request_compression(&mut self) {
+    pub fn disable_request_compression(&self) {
         self.webdav.disable_request_compression();
     }
 

--- a/src/caldav/mod.rs
+++ b/src/caldav/mod.rs
@@ -1,7 +1,9 @@
+pub mod builder;
 pub mod client;
 pub mod streaming;
 pub mod types;
 
+pub use builder::CalDavClientBuilder;
 pub use client::{
     CalDavClient, build_calendar_multiget_body, build_calendar_query_body,
     build_sync_collection_body, map_calendar_list, map_calendar_objects, map_sync_response,

--- a/src/carddav/builder.rs
+++ b/src/carddav/builder.rs
@@ -1,151 +1,33 @@
 //! Builder for [`CardDavClient`] — a thin wrapper over
 //! [`WebDavClientBuilder`] with the same option set.
-
-use std::time::Duration;
-
-use hyper::Uri;
+//!
+//! See [`CardDavClient::builder`](crate::carddav::client::CardDavClient::builder)
+//! for usage.
 
 use crate::carddav::client::CardDavClient;
-use crate::webdav::builder::WebDavClientBuilder;
-use crate::webdav::client::RequestCompressionMode;
+use crate::impl_dav_builder;
 
-/// Builder for [`CardDavClient`].
-///
-/// Created with [`CardDavClient::builder`]. Delegates every option to
-/// [`WebDavClientBuilder`]; only the base URL is required.
-///
-/// # Example
-///
-/// ```no_run
-/// use fast_dav_rs::CardDavClient;
-/// use fast_dav_rs::webdav::RequestCompressionMode;
-/// use std::time::Duration;
-///
-/// let client = CardDavClient::builder("https://card.example.com/dav/user01/")
-///     .basic_auth("user01", "secret")
-///     .timeout(Duration::from_secs(10))
-///     .pool_max_idle_per_host(8)
-///     .request_compression(RequestCompressionMode::Auto)
-///     .build()?;
-/// # Ok::<(), anyhow::Error>(())
-/// ```
-#[derive(Debug)]
-pub struct CardDavClientBuilder {
-    inner: WebDavClientBuilder,
-}
-
-impl CardDavClientBuilder {
-    pub(crate) fn new(base_url: impl Into<String>) -> Self {
-        Self {
-            inner: WebDavClientBuilder::new(base_url),
-        }
-    }
-
-    /// Send **Basic** credentials with every request. Default: no auth.
+impl_dav_builder! {
+    /// Builder for [`CardDavClient`].
     ///
-    /// # Security
+    /// Created with [`CardDavClient::builder`]. Delegates every option to
+    /// [`WebDavClientBuilder`]; only the base URL is required.
     ///
-    /// Basic credentials are sent as an `Authorization: Basic` header on
-    /// **every** request. Base64 is an encoding, not encryption: over plain
-    /// `http://` the credentials travel effectively in cleartext. Always use
-    /// `https://` outside isolated test environments.
-    pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
-        self.inner = self.inner.basic_auth(user, pass);
-        self
-    }
-
-    /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    /// # Example
     ///
-    /// # Security
+    /// ```no_run
+    /// use fast_dav_rs::CardDavClient;
+    /// use fast_dav_rs::webdav::RequestCompressionMode;
+    /// use std::time::Duration;
     ///
-    /// The bearer token is sent as an `Authorization: Bearer` header on
-    /// **every** request. Over plain `http://` the token travels in
-    /// cleartext. Always use `https://` outside isolated test environments.
-    pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
-        self.inner = self.inner.bearer_token(token);
-        self
-    }
-
-    /// Set the default per-request timeout. Default: **20 seconds**.
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.timeout(timeout);
-        self
-    }
-
-    /// Set the TCP connect timeout applied to the connector. Default: **none**.
-    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.connect_timeout(timeout);
-        self
-    }
-
-    /// Set the `User-Agent` header sent on every request. Default: **none**.
-    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
-        self.inner = self.inner.user_agent(ua);
-        self
-    }
-
-    /// Force HTTP/1.1 only (disable HTTP/2 negotiation). Default: **false**.
-    pub fn force_http1(mut self, force: bool) -> Self {
-        self.inner = self.inner.force_http1(force);
-        self
-    }
-
-    /// Cap the number of idle pooled connections kept alive per host.
-    /// Default: **32**.
-    pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
-        self.inner = self.inner.pool_max_idle_per_host(max_idle);
-        self
-    }
-
-    /// Set the idle connection timeout for the pool. Default: **unbounded**.
-    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
-        self.inner = self.inner.pool_idle_timeout(timeout);
-        self
-    }
-
-    /// Choose the request-body compression strategy. Default:
-    /// [`RequestCompressionMode::Auto`].
-    pub fn request_compression(mut self, mode: RequestCompressionMode) -> Self {
-        self.inner = self.inner.request_compression(mode);
-        self
-    }
-
-    /// Route all requests through this proxy (e.g. `http://127.0.0.1:9090`).
-    /// HTTPS is tunneled via HTTP CONNECT. Default: **no proxy**.
-    pub fn proxy(mut self, proxy: impl Into<Uri>) -> Self {
-        self.inner = self.inner.proxy(proxy);
-        self
-    }
-
-    /// Set Basic credentials for the proxy. Default: **no proxy auth**.
-    pub fn proxy_basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
-        self.inner = self.inner.proxy_basic_auth(user, pass);
-        self
-    }
-
-    /// Add additional PEM-encoded trust roots on top of the native/webpki
-    /// roots — e.g. a Proxyman/Charles/mitmproxy root CA. Default: **empty**.
-    pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
-        self.inner = self.inner.extra_root_certs_pem(certs);
-        self
-    }
-
-    /// Accept any server certificate without verification. **Testing/debug
-    /// only — never enable in production.** Default: **false**.
-    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
-        self.inner = self.inner.danger_accept_invalid_certs(accept);
-        self
-    }
-
-    /// Validate the configuration and construct the [`CardDavClient`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the base URL is not a valid URI, if credentials
-    /// are provided but cannot be encoded, if the proxy URI is invalid,
-    /// if `timeout` or `pool_max_idle_per_host` is zero, or if PEM
-    /// certificates cannot be parsed.
-    pub fn build(self) -> anyhow::Result<CardDavClient> {
-        Ok(CardDavClient::from_webdav(self.inner.build()?))
-    }
+    /// let client = CardDavClient::builder("https://card.example.com/dav/user01/")
+    ///     .basic_auth("user01", "secret")
+    ///     .timeout(Duration::from_secs(10))
+    ///     .pool_max_idle_per_host(8)
+    ///     .request_compression(RequestCompressionMode::Auto)
+    ///     .build()?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub struct CardDavClientBuilder;
+    client = CardDavClient;
 }

--- a/src/carddav/builder.rs
+++ b/src/carddav/builder.rs
@@ -42,12 +42,25 @@ impl CardDavClientBuilder {
     }
 
     /// Send **Basic** credentials with every request. Default: no auth.
+    ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on
+    /// **every** request. Base64 is an encoding, not encryption: over plain
+    /// `http://` the credentials travel effectively in cleartext. Always use
+    /// `https://` outside isolated test environments.
     pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
         self.inner = self.inner.basic_auth(user, pass);
         self
     }
 
     /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    ///
+    /// # Security
+    ///
+    /// The bearer token is sent as an `Authorization: Bearer` header on
+    /// **every** request. Over plain `http://` the token travels in
+    /// cleartext. Always use `https://` outside isolated test environments.
     pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
         self.inner = self.inner.bearer_token(token);
         self

--- a/src/carddav/builder.rs
+++ b/src/carddav/builder.rs
@@ -1,0 +1,138 @@
+//! Builder for [`CardDavClient`] — a thin wrapper over
+//! [`WebDavClientBuilder`] with the same option set.
+
+use std::time::Duration;
+
+use hyper::Uri;
+
+use crate::carddav::client::CardDavClient;
+use crate::webdav::builder::WebDavClientBuilder;
+use crate::webdav::client::RequestCompressionMode;
+
+/// Builder for [`CardDavClient`].
+///
+/// Created with [`CardDavClient::builder`]. Delegates every option to
+/// [`WebDavClientBuilder`]; only the base URL is required.
+///
+/// # Example
+///
+/// ```no_run
+/// use fast_dav_rs::CardDavClient;
+/// use fast_dav_rs::webdav::RequestCompressionMode;
+/// use std::time::Duration;
+///
+/// let client = CardDavClient::builder("https://card.example.com/dav/user01/")
+///     .basic_auth("user01", "secret")
+///     .timeout(Duration::from_secs(10))
+///     .pool_max_idle_per_host(8)
+///     .request_compression(RequestCompressionMode::Auto)
+///     .build()?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct CardDavClientBuilder {
+    inner: WebDavClientBuilder,
+}
+
+impl CardDavClientBuilder {
+    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            inner: WebDavClientBuilder::new(base_url),
+        }
+    }
+
+    /// Send **Basic** credentials with every request. Default: no auth.
+    pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.inner = self.inner.basic_auth(user, pass);
+        self
+    }
+
+    /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.inner = self.inner.bearer_token(token);
+        self
+    }
+
+    /// Set the default per-request timeout. Default: **20 seconds**.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
+    /// Set the TCP connect timeout applied to the connector. Default: **none**.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.connect_timeout(timeout);
+        self
+    }
+
+    /// Set the `User-Agent` header sent on every request. Default: **none**.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.inner = self.inner.user_agent(ua);
+        self
+    }
+
+    /// Force HTTP/1.1 only (disable HTTP/2 negotiation). Default: **false**.
+    pub fn force_http1(mut self, force: bool) -> Self {
+        self.inner = self.inner.force_http1(force);
+        self
+    }
+
+    /// Cap the number of idle pooled connections kept alive per host.
+    /// Default: **32**.
+    pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
+        self.inner = self.inner.pool_max_idle_per_host(max_idle);
+        self
+    }
+
+    /// Set the idle connection timeout for the pool. Default: **unbounded**.
+    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.pool_idle_timeout(timeout);
+        self
+    }
+
+    /// Choose the request-body compression strategy. Default:
+    /// [`RequestCompressionMode::Auto`].
+    pub fn request_compression(mut self, mode: RequestCompressionMode) -> Self {
+        self.inner = self.inner.request_compression(mode);
+        self
+    }
+
+    /// Route all requests through this proxy (e.g. `http://127.0.0.1:9090`).
+    /// HTTPS is tunneled via HTTP CONNECT. Default: **no proxy**.
+    pub fn proxy(mut self, proxy: impl Into<Uri>) -> Self {
+        self.inner = self.inner.proxy(proxy);
+        self
+    }
+
+    /// Set Basic credentials for the proxy. Default: **no proxy auth**.
+    pub fn proxy_basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.inner = self.inner.proxy_basic_auth(user, pass);
+        self
+    }
+
+    /// Add additional PEM-encoded trust roots on top of the native/webpki
+    /// roots — e.g. a Proxyman/Charles/mitmproxy root CA. Default: **empty**.
+    pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
+        self.inner = self.inner.extra_root_certs_pem(certs);
+        self
+    }
+
+    /// Accept any server certificate without verification. **Testing/debug
+    /// only — never enable in production.** Default: **false**.
+    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
+        self.inner = self.inner.danger_accept_invalid_certs(accept);
+        self
+    }
+
+    /// Validate the configuration and construct the [`CardDavClient`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the base URL is not a valid URI, if credentials
+    /// are provided but cannot be encoded, if the proxy URI is invalid,
+    /// if `timeout` or `pool_max_idle_per_host` is zero, or if PEM
+    /// certificates cannot be parsed.
+    pub fn build(self) -> anyhow::Result<CardDavClient> {
+        Ok(CardDavClient::from_webdav(self.inner.build()?))
+    }
+}

--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -5,6 +5,7 @@ use hyper::{HeaderMap, Method, Response, StatusCode, Uri, header};
 use std::sync::Arc;
 use tokio::time::Duration;
 
+use crate::carddav::builder::CardDavClientBuilder;
 use crate::carddav::streaming::parse_multistatus_bytes;
 use crate::carddav::types::{
     AddressBookInfo, AddressObject, BatchItem, DavItem, Depth, SyncItem, SyncResponse,
@@ -73,9 +74,37 @@ impl CardDavClient {
     /// # }
     /// ```
     pub fn new(base_url: &str, basic_user: Option<&str>, basic_pass: Option<&str>) -> Result<Self> {
-        Ok(Self {
-            webdav: WebDavClient::new(base_url, basic_user, basic_pass)?,
-        })
+        let mut builder = Self::builder(base_url);
+        if let (Some(u), Some(p)) = (basic_user, basic_pass) {
+            builder = builder.basic_auth(u, p);
+        }
+        builder.build()
+    }
+
+    /// Create a builder for configuring the client before construction.
+    ///
+    /// Only the base URL is required; every other option has a sensible
+    /// default documented on [`CardDavClientBuilder`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fast_dav_rs::CardDavClient;
+    /// use std::time::Duration;
+    ///
+    /// let client = CardDavClient::builder("https://card.example.com/dav/")
+    ///     .basic_auth("user", "pass")
+    ///     .timeout(Duration::from_secs(30))
+    ///     .build()?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn builder(base_url: impl Into<String>) -> CardDavClientBuilder {
+        CardDavClientBuilder::new(base_url)
+    }
+
+    /// Wrap a [`WebDavClient`] into a [`CardDavClient`].
+    pub(crate) fn from_webdav(webdav: WebDavClient) -> Self {
+        Self { webdav }
     }
 
     /// Configure request compression for this client.
@@ -90,7 +119,7 @@ impl CardDavClient {
     /// use fast_dav_rs::{CardDavClient, ContentEncoding};
     ///
     /// # fn example() -> anyhow::Result<()> {
-    /// let mut client = CardDavClient::new(
+    /// let client = CardDavClient::new(
     ///     "https://card.example.com/dav/user01/",
     ///     Some("user01"),
     ///     Some("secret"),
@@ -99,22 +128,22 @@ impl CardDavClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_request_compression(&mut self, encoding: ContentEncoding) {
+    pub fn set_request_compression(&self, encoding: ContentEncoding) {
         self.webdav.set_request_compression(encoding);
     }
 
     /// Configure the request compression strategy.
-    pub fn set_request_compression_mode(&mut self, mode: RequestCompressionMode) {
+    pub fn set_request_compression_mode(&self, mode: RequestCompressionMode) {
         self.webdav.set_request_compression_mode(mode);
     }
 
     /// Enable adaptive request compression (default behaviour).
-    pub fn set_request_compression_auto(&mut self) {
+    pub fn set_request_compression_auto(&self) {
         self.webdav.set_request_compression_auto();
     }
 
     /// Disable request compression entirely.
-    pub fn disable_request_compression(&mut self) {
+    pub fn disable_request_compression(&self) {
         self.webdav.disable_request_compression();
     }
 

--- a/src/carddav/mod.rs
+++ b/src/carddav/mod.rs
@@ -1,9 +1,11 @@
 //! CardDAV client, streaming helpers, and types for addressbook discovery, queries, and sync.
 
+pub mod builder;
 pub mod client;
 pub mod streaming;
 pub mod types;
 
+pub use builder::CardDavClientBuilder;
 pub use client::{
     CardDavClient, build_addressbook_multiget_body, build_addressbook_query_body,
     build_addressbook_query_filter_email, build_addressbook_query_filter_fn,

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -9,12 +9,7 @@ use std::task::{Context, Poll};
 use tower_service::Service;
 
 /// Type alias for the Hyper client used across CalDAV/CardDAV modules.
-///
-/// The `MaybeProxied` connector is `pub(crate)` since it is an implementation
-/// detail of the connector layer; external code consumes it through this
-/// alias.
-#[allow(private_interfaces)]
-pub type HyperClient = Client<hyper_rustls::HttpsConnector<MaybeProxied>, Full<Bytes>>;
+pub(crate) type HyperClient = Client<hyper_rustls::HttpsConnector<MaybeProxied>, Full<Bytes>>;
 
 /// Connector that is either direct or proxied via HTTP CONNECT tunnel.
 ///

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -181,7 +181,14 @@ fn build_rustls_config(
                 let _ = roots.add(cert);
             }
         }
-        _ => {
+        result => {
+            if !result.errors.is_empty() {
+                #[cfg(debug_assertions)]
+                eprintln!(
+                    "fast-dav-rs: falling back to webpki roots (native roots errors: {:?})",
+                    result.errors
+                );
+            }
             roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         }
     }

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,26 +1,18 @@
-use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::Uri;
-use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::client::legacy::connect::proxy::Tunnel;
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
-use hyper_util::rt::TokioExecutor;
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{ClientConfig, RootCertStore};
-use rustls_native_certs::load_native_certs;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::time::Duration;
 use tower_service::Service;
 
 /// Type alias for the Hyper client used across CalDAV/CardDAV modules.
 ///
 /// The `MaybeProxied` connector is `pub(crate)` since it is an implementation
 /// detail of the connector layer; external code consumes it through this
-/// alias and the `build_hyper_client*` constructors.
+/// alias.
 #[allow(private_interfaces)]
 pub type HyperClient = Client<hyper_rustls::HttpsConnector<MaybeProxied>, Full<Bytes>>;
 
@@ -67,211 +59,6 @@ impl Service<Uri> for MaybeProxied {
             }
         }
     }
-}
-
-/// Build a Hyper client with the default idle-connection pool limit.
-///
-/// Thin wrapper around [`build_hyper_client_with_pool`].
-#[allow(private_interfaces)]
-pub fn build_hyper_client() -> Result<HyperClient> {
-    build_hyper_client_with_pool(DEFAULT_POOL_MAX_IDLE_PER_HOST)
-}
-
-/// Build a Hyper client configured with HTTP/2, connection pooling capped at
-/// `pool_max_idle_per_host` idle connections per host, and a TLS connector
-/// that prefers native roots but falls back to the bundled WebPKI store.
-#[allow(private_interfaces)]
-pub fn build_hyper_client_with_pool(pool_max_idle_per_host: usize) -> Result<HyperClient> {
-    let https_builder = HttpsConnectorBuilder::new()
-        .with_native_roots()
-        .unwrap_or_else(|err| {
-            #[cfg(debug_assertions)]
-            eprintln!(
-                "fast-dav-rs: falling back to webpki roots (native roots unavailable: {err})"
-            );
-            HttpsConnectorBuilder::new().with_webpki_roots()
-        });
-
-    let http = HttpConnector::new();
-    let inner = MaybeProxied::Direct(http);
-
-    let https = https_builder
-        .https_or_http()
-        .enable_http1()
-        .enable_http2()
-        .wrap_connector(inner);
-
-    Ok(Client::builder(TokioExecutor::new())
-        .http2_adaptive_window(true)
-        .pool_max_idle_per_host(pool_max_idle_per_host)
-        .build::<_, Full<Bytes>>(https))
-}
-
-/// A certificate verifier that accepts any server certificate.
-///
-/// # Warning
-///
-/// This completely disables TLS certificate verification. Only use in
-/// testing/debug scenarios — never in production.
-#[derive(Debug)]
-struct NoVerify;
-
-impl rustls::client::danger::ServerCertVerifier for NoVerify {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer,
-        _intermediates: &[CertificateDer],
-        _server_name: &ServerName,
-        _ocsp_response: &[u8],
-        _now: UnixTime,
-    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        rustls::crypto::aws_lc_rs::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
-    }
-}
-
-/// Build a rustls `ClientConfig` with native roots (fallback webpki),
-/// optional extra PEM trust roots, and optional danger mode.
-fn build_rustls_config(
-    extra_root_certs_pem: &[Vec<u8>],
-    danger_accept_invalid_certs: bool,
-) -> Result<ClientConfig> {
-    if danger_accept_invalid_certs {
-        #[cfg(debug_assertions)]
-        eprintln!(
-            "fast-dav-rs: WARNING — danger_accept_invalid_certs is enabled, \
-             TLS certificate verification is disabled"
-        );
-
-        let config = ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoVerify))
-            .with_no_client_auth();
-        return Ok(config);
-    }
-
-    let mut roots = RootCertStore::empty();
-
-    match load_native_certs() {
-        result if !result.certs.is_empty() => {
-            for cert in result.certs {
-                let _ = roots.add(cert);
-            }
-        }
-        result => {
-            if !result.errors.is_empty() {
-                #[cfg(debug_assertions)]
-                eprintln!(
-                    "fast-dav-rs: falling back to webpki roots (native roots errors: {:?})",
-                    result.errors
-                );
-            }
-            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        }
-    }
-
-    for pem in extra_root_certs_pem {
-        for cert in rustls_pemfile::certs(&mut pem.as_slice()) {
-            let cert = cert.map_err(|e| anyhow!("failed to parse PEM certificate: {e}"))?;
-            let _ = roots.add(cert);
-        }
-    }
-
-    let config = ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    Ok(config)
-}
-
-/// Build a fully configured Hyper client.
-///
-/// This is the internal function called by `WebDavClientBuilder::build`.
-/// It constructs the connector (with optional proxy tunnel), the TLS
-/// config (with optional extra roots / danger mode), and the Hyper client
-/// with pool settings.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_hyper_client_full(
-    pool_max_idle_per_host: usize,
-    pool_idle_timeout: Option<Duration>,
-    force_http1: bool,
-    connect_timeout: Option<Duration>,
-    proxy: Option<Uri>,
-    proxy_basic_user: Option<String>,
-    proxy_basic_pass: Option<String>,
-    extra_root_certs_pem: &[Vec<u8>],
-    danger_accept_invalid_certs: bool,
-) -> Result<HyperClient> {
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD as B64;
-
-    let mut http = HttpConnector::new();
-    http.enforce_http(false);
-    if let Some(t) = connect_timeout {
-        http.set_connect_timeout(Some(t));
-    }
-
-    let inner = match proxy {
-        Some(proxy_uri) => {
-            let mut tunnel = Tunnel::new(proxy_uri, http);
-            if let (Some(user), Some(pass)) = (proxy_basic_user, proxy_basic_pass) {
-                let basic = B64.encode(format!("{user}:{pass}"));
-                tunnel = tunnel.with_auth(
-                    format!("Basic {basic}")
-                        .parse()
-                        .map_err(|e| anyhow!("invalid proxy auth header: {e}"))?,
-                );
-            }
-            MaybeProxied::Tunneled(tunnel)
-        }
-        None => MaybeProxied::Direct(http),
-    };
-
-    let tls = build_rustls_config(extra_root_certs_pem, danger_accept_invalid_certs)?;
-
-    let https_builder = HttpsConnectorBuilder::new()
-        .with_tls_config(tls)
-        .https_or_http()
-        .enable_http1();
-
-    let https = if force_http1 {
-        https_builder.wrap_connector(inner)
-    } else {
-        https_builder.enable_http2().wrap_connector(inner)
-    };
-
-    let mut builder = Client::builder(TokioExecutor::new());
-    if !force_http1 {
-        builder.http2_adaptive_window(true);
-    }
-    builder.pool_max_idle_per_host(pool_max_idle_per_host);
-    if let Some(t) = pool_idle_timeout {
-        builder.pool_idle_timeout(t);
-    }
-
-    Ok(builder.build::<_, Full<Bytes>>(https))
 }
 
 #[cfg(test)]

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,16 +1,83 @@
 use anyhow::Result;
 use bytes::Bytes;
 use http_body_util::Full;
+use hyper::Uri;
 use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::connect::proxy::Tunnel;
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower_service::Service;
 
 /// Type alias for the Hyper client used across CalDAV/CardDAV modules.
-pub type HyperClient = Client<hyper_rustls::HttpsConnector<HttpConnector>, Full<Bytes>>;
+///
+/// The `MaybeProxied` connector is `pub(crate)` since it is an implementation
+/// detail of the connector layer; external code consumes it through this
+/// alias and the `build_hyper_client*` constructors.
+#[allow(private_interfaces)]
+pub type HyperClient = Client<hyper_rustls::HttpsConnector<MaybeProxied>, Full<Bytes>>;
 
-/// Build a Hyper client configured with HTTP/2, connection pooling, and a TLS connector
-/// that prefers native roots but falls back to the bundled WebPKI store.
+/// Default maximum number of idle pooled connections kept alive per host.
+///
+/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
+/// deployments cap per-client connections well below that (often 10–50),
+/// and keeping 128 idle sockets around needlessly exhausts client file
+/// descriptors and server connection limits.
+pub const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
+
+/// Connector that is either direct or proxied via HTTP CONNECT tunnel.
+///
+/// Implements `tower_service::Service<Uri>` by delegating to the inner
+/// connector. The future is boxed since `HttpConnector` and
+/// `Tunnel<HttpConnector>` produce different future types.
+#[allow(dead_code)] // Tunneled variant wired in Task 5
+#[derive(Clone)]
+pub(crate) enum MaybeProxied {
+    Direct(HttpConnector),
+    Tunneled(Tunnel<HttpConnector>),
+}
+
+impl Service<Uri> for MaybeProxied {
+    type Response = <HttpConnector as Service<Uri>>::Response;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self {
+            MaybeProxied::Direct(c) => c.poll_ready(cx).map_err(|e| Box::new(e) as Self::Error),
+            MaybeProxied::Tunneled(c) => c.poll_ready(cx).map_err(|e| Box::new(e) as Self::Error),
+        }
+    }
+
+    fn call(&mut self, dst: Uri) -> Self::Future {
+        match self {
+            MaybeProxied::Direct(c) => {
+                let fut = c.call(dst);
+                Box::pin(async move { fut.await.map_err(|e| Box::new(e) as Self::Error) })
+            }
+            MaybeProxied::Tunneled(c) => {
+                let fut = c.call(dst);
+                Box::pin(async move { fut.await.map_err(|e| Box::new(e) as Self::Error) })
+            }
+        }
+    }
+}
+
+/// Build a Hyper client with the default idle-connection pool limit.
+///
+/// Thin wrapper around [`build_hyper_client_with_pool`].
+#[allow(private_interfaces)]
 pub fn build_hyper_client() -> Result<HyperClient> {
+    build_hyper_client_with_pool(DEFAULT_POOL_MAX_IDLE_PER_HOST)
+}
+
+/// Build a Hyper client configured with HTTP/2, connection pooling capped at
+/// `pool_max_idle_per_host` idle connections per host, and a TLS connector
+/// that prefers native roots but falls back to the bundled WebPKI store.
+#[allow(private_interfaces)]
+pub fn build_hyper_client_with_pool(pool_max_idle_per_host: usize) -> Result<HyperClient> {
     let https_builder = HttpsConnectorBuilder::new()
         .with_native_roots()
         .unwrap_or_else(|err| {
@@ -21,14 +88,32 @@ pub fn build_hyper_client() -> Result<HyperClient> {
             HttpsConnectorBuilder::new().with_webpki_roots()
         });
 
+    let http = HttpConnector::new();
+    let inner = MaybeProxied::Direct(http);
+
     let https = https_builder
         .https_or_http()
         .enable_http1()
         .enable_http2()
-        .build();
+        .wrap_connector(inner);
 
     Ok(Client::builder(TokioExecutor::new())
         .http2_adaptive_window(true)
-        .pool_max_idle_per_host(128)
+        .pool_max_idle_per_host(pool_max_idle_per_host)
         .build::<_, Full<Bytes>>(https))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_pool_max_idle_is_32() {
+        assert_eq!(DEFAULT_POOL_MAX_IDLE_PER_HOST, 32);
+    }
+
+    #[test]
+    fn maybe_proxied_direct_construction() {
+        let _ = MaybeProxied::Direct(HttpConnector::new());
+    }
 }

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -16,14 +16,6 @@ use tower_service::Service;
 #[allow(private_interfaces)]
 pub type HyperClient = Client<hyper_rustls::HttpsConnector<MaybeProxied>, Full<Bytes>>;
 
-/// Default maximum number of idle pooled connections kept alive per host.
-///
-/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
-/// deployments cap per-client connections well below that (often 10–50),
-/// and keeping 128 idle sockets around needlessly exhausts client file
-/// descriptors and server connection limits.
-pub const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
-
 /// Connector that is either direct or proxied via HTTP CONNECT tunnel.
 ///
 /// Implements `tower_service::Service<Uri>` by delegating to the inner
@@ -64,11 +56,6 @@ impl Service<Uri> for MaybeProxied {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn default_pool_max_idle_is_32() {
-        assert_eq!(DEFAULT_POOL_MAX_IDLE_PER_HOST, 32);
-    }
 
     #[test]
     fn maybe_proxied_direct_construction() {

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::Uri;
@@ -6,9 +6,14 @@ use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::client::legacy::connect::proxy::Tunnel;
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, RootCertStore};
+use rustls_native_certs::load_native_certs;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tower_service::Service;
 
 /// Type alias for the Hyper client used across CalDAV/CardDAV modules.
@@ -32,7 +37,6 @@ pub const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
 /// Implements `tower_service::Service<Uri>` by delegating to the inner
 /// connector. The future is boxed since `HttpConnector` and
 /// `Tunnel<HttpConnector>` produce different future types.
-#[allow(dead_code)] // Tunneled variant wired in Task 5
 #[derive(Clone)]
 pub(crate) enum MaybeProxied {
     Direct(HttpConnector),
@@ -101,6 +105,166 @@ pub fn build_hyper_client_with_pool(pool_max_idle_per_host: usize) -> Result<Hyp
         .http2_adaptive_window(true)
         .pool_max_idle_per_host(pool_max_idle_per_host)
         .build::<_, Full<Bytes>>(https))
+}
+
+/// A certificate verifier that accepts any server certificate.
+///
+/// # Warning
+///
+/// This completely disables TLS certificate verification. Only use in
+/// testing/debug scenarios — never in production.
+#[derive(Debug)]
+struct NoVerify;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer,
+        _intermediates: &[CertificateDer],
+        _server_name: &ServerName,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Build a rustls `ClientConfig` with native roots (fallback webpki),
+/// optional extra PEM trust roots, and optional danger mode.
+fn build_rustls_config(
+    extra_root_certs_pem: &[Vec<u8>],
+    danger_accept_invalid_certs: bool,
+) -> Result<ClientConfig> {
+    if danger_accept_invalid_certs {
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "fast-dav-rs: WARNING — danger_accept_invalid_certs is enabled, \
+             TLS certificate verification is disabled"
+        );
+
+        let config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth();
+        return Ok(config);
+    }
+
+    let mut roots = RootCertStore::empty();
+
+    match load_native_certs() {
+        result if !result.certs.is_empty() => {
+            for cert in result.certs {
+                let _ = roots.add(cert);
+            }
+        }
+        _ => {
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        }
+    }
+
+    for pem in extra_root_certs_pem {
+        for cert in rustls_pemfile::certs(&mut pem.as_slice()) {
+            let cert = cert.map_err(|e| anyhow!("failed to parse PEM certificate: {e}"))?;
+            let _ = roots.add(cert);
+        }
+    }
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(config)
+}
+
+/// Build a fully configured Hyper client.
+///
+/// This is the internal function called by `WebDavClientBuilder::build`.
+/// It constructs the connector (with optional proxy tunnel), the TLS
+/// config (with optional extra roots / danger mode), and the Hyper client
+/// with pool settings.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_hyper_client_full(
+    pool_max_idle_per_host: usize,
+    pool_idle_timeout: Option<Duration>,
+    force_http1: bool,
+    connect_timeout: Option<Duration>,
+    proxy: Option<Uri>,
+    proxy_basic_user: Option<String>,
+    proxy_basic_pass: Option<String>,
+    extra_root_certs_pem: &[Vec<u8>],
+    danger_accept_invalid_certs: bool,
+) -> Result<HyperClient> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as B64;
+
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+    if let Some(t) = connect_timeout {
+        http.set_connect_timeout(Some(t));
+    }
+
+    let inner = match proxy {
+        Some(proxy_uri) => {
+            let mut tunnel = Tunnel::new(proxy_uri, http);
+            if let (Some(user), Some(pass)) = (proxy_basic_user, proxy_basic_pass) {
+                let basic = B64.encode(format!("{user}:{pass}"));
+                tunnel = tunnel.with_auth(
+                    format!("Basic {basic}")
+                        .parse()
+                        .map_err(|e| anyhow!("invalid proxy auth header: {e}"))?,
+                );
+            }
+            MaybeProxied::Tunneled(tunnel)
+        }
+        None => MaybeProxied::Direct(http),
+    };
+
+    let tls = build_rustls_config(extra_root_certs_pem, danger_accept_invalid_certs)?;
+
+    let https_builder = HttpsConnectorBuilder::new()
+        .with_tls_config(tls)
+        .https_or_http()
+        .enable_http1();
+
+    let https = if force_http1 {
+        https_builder.wrap_connector(inner)
+    } else {
+        https_builder.enable_http2().wrap_connector(inner)
+    };
+
+    let mut builder = Client::builder(TokioExecutor::new());
+    if !force_http1 {
+        builder.http2_adaptive_window(true);
+    }
+    builder.pool_max_idle_per_host(pool_max_idle_per_host);
+    if let Some(t) = pool_idle_timeout {
+        builder.pool_idle_timeout(t);
+    }
+
+    Ok(builder.build::<_, Full<Bytes>>(https))
 }
 
 #[cfg(test)]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,6 +5,4 @@ pub use compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
     decompress_stream, detect_encoding, detect_encodings,
 };
-pub use http::{
-    DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient, build_hyper_client, build_hyper_client_with_pool,
-};
+pub use http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient};

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,4 +5,4 @@ pub use compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
     decompress_stream, detect_encoding, detect_encodings,
 };
-pub use http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient};
+pub use http::HyperClient;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,4 +5,3 @@ pub use compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
     decompress_stream, detect_encoding, detect_encodings,
 };
-pub use http::HyperClient;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,4 +5,6 @@ pub use compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
     decompress_stream, detect_encoding, detect_encodings,
 };
-pub use http::{HyperClient, build_hyper_client};
+pub use http::{
+    DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient, build_hyper_client, build_hyper_client_with_pool,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,12 +687,31 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Advanced configuration with the builder
+//!
+//! For production use, the builder pattern gives you full control over
+//! timeouts, connection pool, TLS, proxy, and auth:
+//!
+//! ```no_run
+//! use fast_dav_rs::CalDavClient;
+//! use std::time::Duration;
+//!
+//! let client = CalDavClient::builder("https://cal.example.com/dav/")
+//!     .bearer_token("ya29.token...")
+//!     .timeout(Duration::from_secs(30))
+//!     .user_agent("MyApp/1.0")
+//!     .pool_max_idle_per_host(10)
+//!     .build()?;
+//! # Ok::<(), anyhow::Error>(())
+//! ```
 pub mod caldav;
 pub mod carddav;
 pub mod common;
 pub mod webdav;
 
 // Backwards-compatible re-exports
+pub use caldav::builder::CalDavClientBuilder;
 pub use caldav::streaming::{
     parse_multistatus_bytes, parse_multistatus_bytes_visit, parse_multistatus_stream,
     parse_multistatus_stream_visit, parse_multistatus_stream_visit_with_timeout,
@@ -703,11 +722,14 @@ pub use caldav::{
     build_calendar_multiget_body, build_calendar_query_body, build_sync_collection_body,
     map_calendar_list, map_calendar_objects, map_sync_response,
 };
+pub use carddav::builder::CardDavClientBuilder;
 pub use carddav::{AddressBookInfo, AddressObject, CardDavClient};
 pub use common::compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, detect_encoding,
     detect_encodings, detect_request_compression_preference,
 };
+pub use webdav::builder::WebDavClientBuilder;
+pub use webdav::{RequestCompressionMode, WebDavClient};
 
 // Legacy module paths kept for compatibility with existing imports.
 pub mod client {

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -1,0 +1,428 @@
+//! Builder for [`WebDavClient`] — configure auth, timeout, connection pool,
+//! TLS, proxy, and request compression before the client is constructed.
+
+use anyhow::{Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use hyper::{Uri, header};
+use std::time::Duration;
+use zeroize::Zeroize;
+
+use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, build_hyper_client_with_pool};
+use crate::webdav::client::{RequestCompressionMode, WebDavClient};
+
+/// Default request timeout applied when [`WebDavClientBuilder::timeout`] is
+/// not called (and by the `new()` convenience constructors).
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Builder for [`WebDavClient`].
+///
+/// Created with [`WebDavClient::builder`]. Every option is optional and
+/// documented with its default; only the base URL is required.
+///
+/// # Example
+///
+/// ```no_run
+/// use fast_dav_rs::webdav::{RequestCompressionMode, WebDavClient};
+/// use std::time::Duration;
+///
+/// let client = WebDavClient::builder("https://dav.example.com/user01/")
+///     .basic_auth("user01", "secret")
+///     .timeout(Duration::from_secs(10))
+///     .pool_max_idle_per_host(8)
+///     .request_compression(RequestCompressionMode::Auto)
+///     .build()?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub struct WebDavClientBuilder {
+    base_url: String,
+    basic_user: Option<String>,
+    basic_pass: Option<String>,
+    bearer_token: Option<String>,
+    timeout: Duration,
+    connect_timeout: Option<Duration>,
+    user_agent: Option<String>,
+    force_http1: bool,
+    pool_max_idle_per_host: usize,
+    pool_idle_timeout: Option<Duration>,
+    request_compression: RequestCompressionMode,
+    proxy: Option<Uri>,
+    proxy_basic_user: Option<String>,
+    proxy_basic_pass: Option<String>,
+    extra_root_certs_pem: Vec<Vec<u8>>,
+    danger_accept_invalid_certs: bool,
+}
+
+/// Manual implementation so held Basic/Bearer credentials are never printed.
+impl std::fmt::Debug for WebDavClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebDavClientBuilder")
+            .field("base_url", &self.base_url)
+            .field(
+                "basic_auth",
+                &self.basic_user.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "bearer_token",
+                &self.bearer_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("timeout", &self.timeout)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("user_agent", &self.user_agent)
+            .field("force_http1", &self.force_http1)
+            .field("pool_max_idle_per_host", &self.pool_max_idle_per_host)
+            .field("pool_idle_timeout", &self.pool_idle_timeout)
+            .field("request_compression", &self.request_compression)
+            .field("proxy", &self.proxy)
+            .field(
+                "proxy_basic_auth",
+                &self.proxy_basic_user.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "extra_root_certs_pem_count",
+                &self.extra_root_certs_pem.len(),
+            )
+            .field(
+                "danger_accept_invalid_certs",
+                &self.danger_accept_invalid_certs,
+            )
+            .finish()
+    }
+}
+
+impl WebDavClientBuilder {
+    /// Start a builder for the given **base URL** (collection/home-set).
+    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            basic_user: None,
+            basic_pass: None,
+            bearer_token: None,
+            timeout: DEFAULT_TIMEOUT,
+            connect_timeout: None,
+            user_agent: None,
+            force_http1: false,
+            pool_max_idle_per_host: DEFAULT_POOL_MAX_IDLE_PER_HOST,
+            pool_idle_timeout: None,
+            request_compression: RequestCompressionMode::Auto,
+            proxy: None,
+            proxy_basic_user: None,
+            proxy_basic_pass: None,
+            extra_root_certs_pem: Vec::new(),
+            danger_accept_invalid_certs: false,
+        }
+    }
+
+    /// Send **Basic** credentials with every request. Default: no auth.
+    ///
+    /// Calling this after [`bearer_token`](Self::bearer_token) clears the
+    /// bearer token — the last auth method called wins.
+    ///
+    /// # Security
+    ///
+    /// Basic credentials are sent as an `Authorization: Basic` header on
+    /// **every** request. Base64 is an encoding, not encryption: over plain
+    /// `http://` the credentials travel effectively in cleartext and can be
+    /// read by anyone on the network path. Always use `https://` outside
+    /// isolated test environments (e.g. a local Docker test server).
+    pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.basic_user = Some(user.into());
+        self.basic_pass = Some(pass.into());
+        self.bearer_token = None;
+        self
+    }
+
+    /// Send a **Bearer** token with every request (OAuth 2.0). Default: no auth.
+    ///
+    /// Calling this after [`basic_auth`](Self::basic_auth) clears the Basic
+    /// credentials — the last auth method called wins.
+    ///
+    /// # Security
+    ///
+    /// The bearer token is sent as an `Authorization: Bearer` header on
+    /// **every** request. Over plain `http://` the token travels in
+    /// cleartext. Always use `https://` outside isolated test environments.
+    pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.bearer_token = Some(token.into());
+        self.basic_user = None;
+        self.basic_pass = None;
+        self
+    }
+
+    /// Set the default per-request timeout. Default: **20 seconds**.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Set the TCP connect timeout applied to the connector. Default: **none**.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the `User-Agent` header sent on every request. Default: **none**.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(ua.into());
+        self
+    }
+
+    /// Force HTTP/1.1 only (disable HTTP/2 negotiation). Default: **false**.
+    ///
+    /// Useful for servers or proxies that misbehave with HTTP/2.
+    pub fn force_http1(mut self, force: bool) -> Self {
+        self.force_http1 = force;
+        self
+    }
+
+    /// Cap the number of idle pooled connections kept alive per host.
+    /// Default: **32**.
+    pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
+        self.pool_max_idle_per_host = max_idle;
+        self
+    }
+
+    /// Set the idle connection timeout for the pool. Default: **unbounded**.
+    pub fn pool_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.pool_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Choose the request-body compression strategy. Default:
+    /// [`RequestCompressionMode::Auto`].
+    pub fn request_compression(mut self, mode: RequestCompressionMode) -> Self {
+        self.request_compression = mode;
+        self
+    }
+
+    /// Route all requests through this proxy (e.g. `http://127.0.0.1:9090`).
+    /// HTTPS is tunneled via HTTP CONNECT. Default: **no proxy**.
+    pub fn proxy(mut self, proxy: impl Into<Uri>) -> Self {
+        self.proxy = Some(proxy.into());
+        self
+    }
+
+    /// Set Basic credentials for the proxy. Default: **no proxy auth**.
+    pub fn proxy_basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+        self.proxy_basic_user = Some(user.into());
+        self.proxy_basic_pass = Some(pass.into());
+        self
+    }
+
+    /// Add additional PEM-encoded trust roots on top of the native/webpki
+    /// roots — e.g. a Proxyman/Charles/mitmproxy root CA. Default: **empty**.
+    pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
+        self.extra_root_certs_pem = certs;
+        self
+    }
+
+    /// # Danger
+    ///
+    /// Accept any server certificate without verification. **Testing/debug
+    /// only — never enable in production.** Default: **false**.
+    ///
+    /// This bypasses all TLS certificate validation. Any HTTPS connection
+    /// will succeed regardless of the server's certificate, including
+    /// self-signed, expired, or mismatched certificates. Use
+    /// [`extra_root_certs_pem`](Self::extra_root_certs_pem) instead when
+    /// you need to trust a specific custom CA.
+    pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
+        self.danger_accept_invalid_certs = accept;
+        self
+    }
+
+    /// Validate the configuration and construct the [`WebDavClient`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the base URL is not a valid URI, if credentials
+    /// are provided but cannot be encoded, if the proxy URI is invalid,
+    /// if `timeout` or `pool_max_idle_per_host` is zero, or if PEM
+    /// certificates cannot be parsed.
+    pub fn build(mut self) -> Result<WebDavClient> {
+        if self.timeout.is_zero() {
+            return Err(anyhow!("timeout must be > 0"));
+        }
+        if self.pool_max_idle_per_host == 0 {
+            return Err(anyhow!("pool_max_idle_per_host must be > 0"));
+        }
+
+        let base: Uri = self
+            .base_url
+            .parse()
+            .map_err(|e: hyper::http::uri::InvalidUri| {
+                anyhow!("invalid URL {:?}: {e}", self.base_url)
+            })?;
+
+        let auth_header = build_auth_header(
+            self.basic_user.take(),
+            self.basic_pass.take(),
+            self.bearer_token.take(),
+        )?;
+
+        let user_agent = match self.user_agent.take() {
+            Some(ua) => Some(
+                header::HeaderValue::from_str(&ua)
+                    .map_err(|e| anyhow!("invalid User-Agent header value: {e}"))?,
+            ),
+            None => None,
+        };
+
+        let hyper_client = build_hyper_client_with_pool(self.pool_max_idle_per_host)?;
+
+        Ok(WebDavClient::from_parts(
+            base,
+            hyper_client,
+            auth_header,
+            user_agent,
+            self.timeout,
+            self.request_compression,
+        ))
+    }
+}
+
+impl Drop for WebDavClientBuilder {
+    fn drop(&mut self) {
+        self.basic_user.zeroize();
+        self.basic_pass.zeroize();
+        self.bearer_token.zeroize();
+        self.proxy_basic_user.zeroize();
+        self.proxy_basic_pass.zeroize();
+    }
+}
+
+/// Build the `Authorization` header from whichever auth method was set.
+/// Zeroizes intermediate credential strings.
+fn build_auth_header(
+    basic_user: Option<String>,
+    basic_pass: Option<String>,
+    bearer_token: Option<String>,
+) -> Result<Option<header::HeaderValue>> {
+    if let Some(mut token) = bearer_token {
+        let header_value = header::HeaderValue::from_str(&format!("Bearer {token}"));
+        token.zeroize();
+        return Ok(Some(header_value?));
+    }
+    if let (Some(mut user), Some(mut pass)) = (basic_user, basic_pass) {
+        let header_value = build_basic_auth_header(&user, &pass);
+        user.zeroize();
+        pass.zeroize();
+        return Ok(Some(header_value?));
+    }
+    Ok(None)
+}
+
+/// Build the `Authorization: Basic …` header value, zeroizing the
+/// intermediate strings so plaintext credentials do not linger in freed
+/// heap memory.
+fn build_basic_auth_header(user: &str, pass: &str) -> Result<header::HeaderValue> {
+    let mut token = format!("{}:{}", user, pass);
+    let mut val = format!("Basic {}", B64.encode(&token));
+    let header_value = header::HeaderValue::from_str(&val);
+    token.zeroize();
+    val.zeroize();
+    Ok(header_value?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::compression::ContentEncoding;
+
+    const BASE: &str = "https://dav.example.com/user01/";
+
+    #[test]
+    fn defaults_match_documented_values() {
+        let builder = WebDavClient::builder(BASE);
+        assert_eq!(builder.timeout, DEFAULT_TIMEOUT);
+        assert_eq!(builder.timeout, Duration::from_secs(20));
+        assert_eq!(builder.pool_max_idle_per_host, 32);
+        assert_eq!(builder.request_compression, RequestCompressionMode::Auto);
+        assert!(builder.basic_user.is_none());
+        assert!(builder.basic_pass.is_none());
+        assert!(builder.bearer_token.is_none());
+        assert!(!builder.force_http1);
+        assert!(!builder.danger_accept_invalid_certs);
+    }
+
+    #[test]
+    fn basic_auth_header_correct() {
+        let client = WebDavClient::builder(BASE)
+            .basic_auth("user", "pass")
+            .build()
+            .unwrap();
+        let header = client.basic_auth_header().expect("auth header present");
+        assert_eq!(header.to_str().unwrap(), "Basic dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn bearer_auth_header_correct() {
+        let client = WebDavClient::builder(BASE)
+            .bearer_token("ya29.token")
+            .build()
+            .unwrap();
+        let header = client.basic_auth_header().expect("auth header present");
+        assert_eq!(header.to_str().unwrap(), "Bearer ya29.token");
+    }
+
+    #[test]
+    fn auth_mutual_exclusivity_last_wins() {
+        let client = WebDavClient::builder(BASE)
+            .basic_auth("user", "pass")
+            .bearer_token("token123")
+            .build()
+            .unwrap();
+        let header = client.basic_auth_header().expect("auth header present");
+        assert_eq!(header.to_str().unwrap(), "Bearer token123");
+    }
+
+    #[test]
+    fn no_auth_means_no_header() {
+        let client = WebDavClient::builder(BASE).build().unwrap();
+        assert!(client.basic_auth_header().is_none());
+    }
+
+    #[test]
+    fn debug_redacts_credentials() {
+        let builder = WebDavClient::builder(BASE).basic_auth("user", "hunter2");
+        let debug = format!("{builder:?}");
+        assert!(debug.contains("<redacted>"), "debug output: {debug}");
+        assert!(!debug.contains("hunter2"), "debug output: {debug}");
+    }
+
+    #[test]
+    fn invalid_url_errors() {
+        let result = WebDavClient::builder("not a valid url").build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn clone_shares_compression_mode() {
+        let client_a = WebDavClient::builder(BASE)
+            .request_compression(RequestCompressionMode::Force(ContentEncoding::Zstd))
+            .build()
+            .unwrap();
+        let client_b = client_a.clone();
+
+        client_a.set_request_compression_mode(RequestCompressionMode::Disabled);
+
+        assert_eq!(
+            client_b.request_compression_mode(),
+            RequestCompressionMode::Disabled
+        );
+    }
+
+    #[test]
+    fn timeout_zero_errors() {
+        let result = WebDavClient::builder(BASE).timeout(Duration::ZERO).build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pool_zero_errors() {
+        let result = WebDavClient::builder(BASE)
+            .pool_max_idle_per_host(0)
+            .build();
+        assert!(result.is_err());
+    }
+}

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -8,7 +8,7 @@ use hyper::{Uri, header};
 use std::time::Duration;
 use zeroize::Zeroize;
 
-use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, build_hyper_client_with_pool};
+use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, build_hyper_client_full};
 use crate::webdav::client::{RequestCompressionMode, WebDavClient};
 
 /// Default request timeout applied when [`WebDavClientBuilder::timeout`] is
@@ -268,7 +268,17 @@ impl WebDavClientBuilder {
             None => None,
         };
 
-        let hyper_client = build_hyper_client_with_pool(self.pool_max_idle_per_host)?;
+        let hyper_client = build_hyper_client_full(
+            self.pool_max_idle_per_host,
+            self.pool_idle_timeout,
+            self.force_http1,
+            self.connect_timeout,
+            self.proxy.take(),
+            self.proxy_basic_user.take(),
+            self.proxy_basic_pass.take(),
+            &self.extra_root_certs_pem,
+            self.danger_accept_invalid_certs,
+        )?;
 
         Ok(WebDavClient::from_parts(
             base,

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -56,37 +56,34 @@ pub struct WebDavClientBuilder {
 /// Manual implementation so held Basic/Bearer credentials are never printed.
 impl std::fmt::Debug for WebDavClientBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WebDavClientBuilder")
-            .field("base_url", &self.base_url)
-            .field(
-                "basic_auth",
-                &self.basic_user.as_ref().map(|_| "<redacted>"),
-            )
-            .field(
-                "bearer_token",
-                &self.bearer_token.as_ref().map(|_| "<redacted>"),
-            )
-            .field("timeout", &self.timeout)
+        let mut d = f.debug_struct("WebDavClientBuilder");
+        d.field("base_url", &self.base_url);
+        if self.basic_user.is_some() {
+            d.field("basic_auth", &"<redacted>");
+        }
+        if self.bearer_token.is_some() {
+            d.field("bearer_token", &"<redacted>");
+        }
+        d.field("timeout", &self.timeout)
             .field("connect_timeout", &self.connect_timeout)
             .field("user_agent", &self.user_agent)
             .field("force_http1", &self.force_http1)
             .field("pool_max_idle_per_host", &self.pool_max_idle_per_host)
             .field("pool_idle_timeout", &self.pool_idle_timeout)
             .field("request_compression", &self.request_compression)
-            .field("proxy", &self.proxy)
-            .field(
-                "proxy_basic_auth",
-                &self.proxy_basic_user.as_ref().map(|_| "<redacted>"),
-            )
-            .field(
-                "extra_root_certs_pem_count",
-                &self.extra_root_certs_pem.len(),
-            )
-            .field(
-                "danger_accept_invalid_certs",
-                &self.danger_accept_invalid_certs,
-            )
-            .finish()
+            .field("proxy", &self.proxy);
+        if self.proxy_basic_user.is_some() {
+            d.field("proxy_basic_auth", &"<redacted>");
+        }
+        d.field(
+            "extra_root_certs_pem_count",
+            &self.extra_root_certs_pem.len(),
+        )
+        .field(
+            "danger_accept_invalid_certs",
+            &self.danger_accept_invalid_certs,
+        )
+        .finish()
     }
 }
 
@@ -251,11 +248,35 @@ impl WebDavClientBuilder {
         {
             return Err(anyhow!("bearer_token must not be empty"));
         }
+        if let Some(token) = &self.bearer_token
+            && !token.bytes().all(|b| {
+                b.is_ascii_alphanumeric()
+                    || matches!(b, b'-' | b'.' | b'_' | b'~' | b'+' | b'/' | b'=')
+            })
+        {
+            return Err(anyhow!(
+                "bearer_token contains invalid characters (allowed: A-Z a-z 0-9 - . _ ~ + / =)"
+            ));
+        }
         if let (Some(user), Some(pass)) = (&self.basic_user, &self.basic_pass)
             && (user.is_empty() || pass.is_empty())
         {
             return Err(anyhow!(
                 "basic_auth requires both user and pass to be non-empty"
+            ));
+        }
+        if self.proxy.is_none()
+            && (self.proxy_basic_user.is_some() || self.proxy_basic_pass.is_some())
+        {
+            return Err(anyhow!(
+                "proxy_basic_auth requires a proxy to be set via .proxy()"
+            ));
+        }
+        if let (Some(user), Some(pass)) = (&self.proxy_basic_user, &self.proxy_basic_pass)
+            && (user.is_empty() || pass.is_empty())
+        {
+            return Err(anyhow!(
+                "proxy_basic_auth requires both user and pass to be non-empty"
             ));
         }
 

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -246,6 +246,18 @@ impl WebDavClientBuilder {
         if self.pool_max_idle_per_host == 0 {
             return Err(anyhow!("pool_max_idle_per_host must be > 0"));
         }
+        if let Some(token) = &self.bearer_token
+            && token.is_empty()
+        {
+            return Err(anyhow!("bearer_token must not be empty"));
+        }
+        if let (Some(user), Some(pass)) = (&self.basic_user, &self.basic_pass)
+            && (user.is_empty() || pass.is_empty())
+        {
+            return Err(anyhow!(
+                "basic_auth requires both user and pass to be non-empty"
+            ));
+        }
 
         let base: Uri = self
             .base_url

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -18,12 +18,20 @@ use std::sync::Arc;
 use std::time::Duration;
 use zeroize::Zeroize;
 
-use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient, MaybeProxied};
+use crate::common::http::{HyperClient, MaybeProxied};
 use crate::webdav::client::{RequestCompressionMode, WebDavClient};
 
 /// Default request timeout applied when [`WebDavClientBuilder::timeout`] is
 /// not called (and by the `new()` convenience constructors).
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default maximum number of idle pooled connections kept alive per host.
+///
+/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
+/// deployments cap per-client connections well below that (often 10–50),
+/// and keeping 128 idle sockets around needlessly exhausts client file
+/// descriptors and server connection limits.
+pub(crate) const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
 
 /// Builder for [`WebDavClient`].
 ///

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -93,15 +93,6 @@ impl std::fmt::Debug for WebDavClientBuilder {
     }
 }
 
-/// Default per-request timeout.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// Default maximum number of idle pooled connections per host.
-///
-/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
-/// deployments cap per-client connections well below that (often 10–50).
-const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
-
 impl Default for WebDavClientBuilder {
     fn default() -> Self {
         Self {
@@ -109,11 +100,11 @@ impl Default for WebDavClientBuilder {
             basic_user: None,
             basic_pass: None,
             bearer_token: None,
-            timeout: DEFAULT_TIMEOUT,
+            timeout: Duration::from_secs(20),
             connect_timeout: None,
             user_agent: None,
             force_http1: false,
-            pool_max_idle_per_host: DEFAULT_POOL_MAX_IDLE_PER_HOST,
+            pool_max_idle_per_host: 32,
             pool_idle_timeout: None,
             request_compression: RequestCompressionMode::default(),
             proxy: None,
@@ -678,7 +669,6 @@ mod tests {
     #[test]
     fn defaults_match_documented_values() {
         let builder = WebDavClient::builder(BASE);
-        assert_eq!(builder.timeout, DEFAULT_TIMEOUT);
         assert_eq!(builder.timeout, Duration::from_secs(20));
         assert_eq!(builder.pool_max_idle_per_host, 32);
         assert_eq!(builder.request_compression, RequestCompressionMode::Auto);

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -21,18 +21,6 @@ use zeroize::Zeroize;
 use crate::common::http::{HyperClient, MaybeProxied};
 use crate::webdav::client::{RequestCompressionMode, WebDavClient};
 
-/// Default request timeout applied when [`WebDavClientBuilder::timeout`] is
-/// not called (and by the `new()` convenience constructors).
-pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// Default maximum number of idle pooled connections kept alive per host.
-///
-/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
-/// deployments cap per-client connections well below that (often 10–50),
-/// and keeping 128 idle sockets around needlessly exhausts client file
-/// descriptors and server connection limits.
-pub(crate) const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
-
 /// Builder for [`WebDavClient`].
 ///
 /// Created with [`WebDavClient::builder`]. Every option is optional and
@@ -105,11 +93,19 @@ impl std::fmt::Debug for WebDavClientBuilder {
     }
 }
 
-impl WebDavClientBuilder {
-    /// Start a builder for the given **base URL** (collection/home-set).
-    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+/// Default per-request timeout.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Default maximum number of idle pooled connections per host.
+///
+/// Lowered from the previous hardcoded `128`: typical CalDAV/CardDAV
+/// deployments cap per-client connections well below that (often 10–50).
+const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 32;
+
+impl Default for WebDavClientBuilder {
+    fn default() -> Self {
         Self {
-            base_url: base_url.into(),
+            base_url: String::new(),
             basic_user: None,
             basic_pass: None,
             bearer_token: None,
@@ -119,13 +115,22 @@ impl WebDavClientBuilder {
             force_http1: false,
             pool_max_idle_per_host: DEFAULT_POOL_MAX_IDLE_PER_HOST,
             pool_idle_timeout: None,
-            request_compression: RequestCompressionMode::Auto,
+            request_compression: RequestCompressionMode::default(),
             proxy: None,
             proxy_basic_user: None,
             proxy_basic_pass: None,
             extra_root_certs_pem: Vec::new(),
             danger_accept_invalid_certs: false,
         }
+    }
+}
+
+impl WebDavClientBuilder {
+    /// Start a builder for the given **base URL** (collection/home-set).
+    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+        let mut builder = Self::default();
+        builder.base_url = base_url.into();
+        builder
     }
 
     /// Send **Basic** credentials with every request. Default: no auth.

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -324,17 +324,17 @@ impl WebDavClientBuilder {
             None => None,
         };
 
-        let hyper_client = build_hyper_client(
-            self.pool_max_idle_per_host,
-            self.pool_idle_timeout,
-            self.force_http1,
-            self.connect_timeout,
-            self.proxy.take(),
-            self.proxy_basic_user.take(),
-            self.proxy_basic_pass.take(),
-            &self.extra_root_certs_pem,
-            self.danger_accept_invalid_certs,
-        )?;
+        let hyper_client = build_hyper_client(HyperClientConfig {
+            pool_max_idle_per_host: self.pool_max_idle_per_host,
+            pool_idle_timeout: self.pool_idle_timeout,
+            force_http1: self.force_http1,
+            connect_timeout: self.connect_timeout,
+            proxy: self.proxy.take(),
+            proxy_basic_user: self.proxy_basic_user.take(),
+            proxy_basic_pass: self.proxy_basic_pass.take(),
+            extra_root_certs_pem: std::mem::take(&mut self.extra_root_certs_pem),
+            danger_accept_invalid_certs: self.danger_accept_invalid_certs,
+        })?;
 
         Ok(WebDavClient::from_parts(
             base,
@@ -497,13 +497,8 @@ fn build_rustls_config(
 // Hyper client construction
 // ---------------------------------------------------------------------------
 
-/// Build a fully configured Hyper client.
-///
-/// Constructs the connector (with optional proxy tunnel), the TLS config
-/// (with optional extra roots / danger mode), and the Hyper client with
-/// pool settings. Called by [`WebDavClientBuilder::build`].
-#[allow(clippy::too_many_arguments)]
-fn build_hyper_client(
+/// Configuration for the Hyper client connector, TLS, and pool.
+struct HyperClientConfig {
     pool_max_idle_per_host: usize,
     pool_idle_timeout: Option<Duration>,
     force_http1: bool,
@@ -511,19 +506,26 @@ fn build_hyper_client(
     proxy: Option<Uri>,
     proxy_basic_user: Option<String>,
     proxy_basic_pass: Option<String>,
-    extra_root_certs_pem: &[Vec<u8>],
+    extra_root_certs_pem: Vec<Vec<u8>>,
     danger_accept_invalid_certs: bool,
-) -> Result<HyperClient> {
+}
+
+/// Build a fully configured Hyper client.
+///
+/// Constructs the connector (with optional proxy tunnel), the TLS config
+/// (with optional extra roots / danger mode), and the Hyper client with
+/// pool settings. Called by [`WebDavClientBuilder::build`].
+fn build_hyper_client(cfg: HyperClientConfig) -> Result<HyperClient> {
     let mut http = HttpConnector::new();
     http.enforce_http(false);
-    if let Some(t) = connect_timeout {
+    if let Some(t) = cfg.connect_timeout {
         http.set_connect_timeout(Some(t));
     }
 
-    let inner = match proxy {
+    let inner = match cfg.proxy {
         Some(proxy_uri) => {
             let mut tunnel = Tunnel::new(proxy_uri, http);
-            if let (Some(user), Some(pass)) = (proxy_basic_user, proxy_basic_pass) {
+            if let (Some(user), Some(pass)) = (cfg.proxy_basic_user, cfg.proxy_basic_pass) {
                 let basic = B64.encode(format!("{user}:{pass}"));
                 tunnel = tunnel.with_auth(
                     format!("Basic {basic}")
@@ -536,29 +538,134 @@ fn build_hyper_client(
         None => MaybeProxied::Direct(http),
     };
 
-    let tls = build_rustls_config(extra_root_certs_pem, danger_accept_invalid_certs)?;
+    let tls = build_rustls_config(&cfg.extra_root_certs_pem, cfg.danger_accept_invalid_certs)?;
 
     let https_builder = HttpsConnectorBuilder::new()
         .with_tls_config(tls)
         .https_or_http()
         .enable_http1();
 
-    let https = if force_http1 {
+    let https = if cfg.force_http1 {
         https_builder.wrap_connector(inner)
     } else {
         https_builder.enable_http2().wrap_connector(inner)
     };
 
     let mut builder = Client::builder(TokioExecutor::new());
-    if !force_http1 {
+    if !cfg.force_http1 {
         builder.http2_adaptive_window(true);
     }
-    builder.pool_max_idle_per_host(pool_max_idle_per_host);
-    if let Some(t) = pool_idle_timeout {
+    builder.pool_max_idle_per_host(cfg.pool_max_idle_per_host);
+    if let Some(t) = cfg.pool_idle_timeout {
         builder.pool_idle_timeout(t);
     }
 
     Ok(builder.build::<_, Full<Bytes>>(https))
+}
+
+// ---------------------------------------------------------------------------
+// Delegation macro for thin wrapper builders (CalDav, CardDav)
+// ---------------------------------------------------------------------------
+
+/// Generates a thin wrapper builder that delegates all setters to
+/// [`WebDavClientBuilder`] and wraps the result via `from_webdav`.
+#[macro_export]
+macro_rules! impl_dav_builder {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $builder:ident;
+        client = $client:ty;
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug)]
+        $vis struct $builder {
+            inner: $crate::webdav::builder::WebDavClientBuilder,
+        }
+
+        impl $builder {
+            pub(crate) fn new(base_url: impl Into<String>) -> Self {
+                Self {
+                    inner: $crate::webdav::builder::WebDavClientBuilder::new(base_url),
+                }
+            }
+
+            pub fn basic_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
+                self.inner = self.inner.basic_auth(user, pass);
+                self
+            }
+
+            pub fn bearer_token(mut self, token: impl Into<String>) -> Self {
+                self.inner = self.inner.bearer_token(token);
+                self
+            }
+
+            pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
+                self.inner = self.inner.timeout(timeout);
+                self
+            }
+
+            pub fn connect_timeout(mut self, timeout: std::time::Duration) -> Self {
+                self.inner = self.inner.connect_timeout(timeout);
+                self
+            }
+
+            pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+                self.inner = self.inner.user_agent(ua);
+                self
+            }
+
+            pub fn force_http1(mut self, force: bool) -> Self {
+                self.inner = self.inner.force_http1(force);
+                self
+            }
+
+            pub fn pool_max_idle_per_host(mut self, max_idle: usize) -> Self {
+                self.inner = self.inner.pool_max_idle_per_host(max_idle);
+                self
+            }
+
+            pub fn pool_idle_timeout(mut self, timeout: std::time::Duration) -> Self {
+                self.inner = self.inner.pool_idle_timeout(timeout);
+                self
+            }
+
+            pub fn request_compression(
+                mut self,
+                mode: $crate::webdav::client::RequestCompressionMode,
+            ) -> Self {
+                self.inner = self.inner.request_compression(mode);
+                self
+            }
+
+            pub fn proxy(mut self, proxy: impl Into<hyper::Uri>) -> Self {
+                self.inner = self.inner.proxy(proxy);
+                self
+            }
+
+            pub fn proxy_basic_auth(
+                mut self,
+                user: impl Into<String>,
+                pass: impl Into<String>,
+            ) -> Self {
+                self.inner = self.inner.proxy_basic_auth(user, pass);
+                self
+            }
+
+            pub fn extra_root_certs_pem(mut self, certs: Vec<Vec<u8>>) -> Self {
+                self.inner = self.inner.extra_root_certs_pem(certs);
+                self
+            }
+
+            pub fn danger_accept_invalid_certs(mut self, accept: bool) -> Self {
+                self.inner = self.inner.danger_accept_invalid_certs(accept);
+                self
+            }
+
+            pub fn build(self) -> anyhow::Result<$client> {
+                Ok(<$client>::from_webdav(self.inner.build()?))
+            }
+        }
+    };
 }
 
 #[cfg(test)]
@@ -588,7 +695,7 @@ mod tests {
             .basic_auth("user", "pass")
             .build()
             .unwrap();
-        let header = client.basic_auth_header().expect("auth header present");
+        let header = client.auth_header().expect("auth header present");
         assert_eq!(header.to_str().unwrap(), "Basic dXNlcjpwYXNz");
     }
 
@@ -598,7 +705,7 @@ mod tests {
             .bearer_token("ya29.token")
             .build()
             .unwrap();
-        let header = client.basic_auth_header().expect("auth header present");
+        let header = client.auth_header().expect("auth header present");
         assert_eq!(header.to_str().unwrap(), "Bearer ya29.token");
     }
 
@@ -609,14 +716,14 @@ mod tests {
             .bearer_token("token123")
             .build()
             .unwrap();
-        let header = client.basic_auth_header().expect("auth header present");
+        let header = client.auth_header().expect("auth header present");
         assert_eq!(header.to_str().unwrap(), "Bearer token123");
     }
 
     #[test]
     fn no_auth_means_no_header() {
         let client = WebDavClient::builder(BASE).build().unwrap();
-        assert!(client.basic_auth_header().is_none());
+        assert!(client.auth_header().is_none());
     }
 
     #[test]
@@ -661,5 +768,102 @@ mod tests {
             .pool_max_idle_per_host(0)
             .build();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn auth_bearer_then_basic_last_wins() {
+        let client = WebDavClient::builder(BASE)
+            .bearer_token("token123")
+            .basic_auth("user", "pass")
+            .build()
+            .unwrap();
+        let header = client.auth_header().expect("auth header present");
+        assert_eq!(header.to_str().unwrap(), "Basic dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn empty_basic_user_errors() {
+        let result = WebDavClient::builder(BASE).basic_auth("", "pass").build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_basic_pass_errors() {
+        let result = WebDavClient::builder(BASE).basic_auth("user", "").build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_bearer_token_errors() {
+        let result = WebDavClient::builder(BASE).bearer_token("").build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_bearer_chars_errors() {
+        let result = WebDavClient::builder(BASE)
+            .bearer_token("has space")
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_auth_without_proxy_errors() {
+        let result = WebDavClient::builder(BASE)
+            .proxy_basic_auth("user", "pass")
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn debug_redacts_bearer_token() {
+        let builder = WebDavClient::builder(BASE).bearer_token("secret-token");
+        let debug = format!("{builder:?}");
+        assert!(debug.contains("<redacted>"), "debug output: {debug}");
+        assert!(!debug.contains("secret-token"), "debug output: {debug}");
+    }
+
+    #[test]
+    fn debug_omits_auth_fields_when_none() {
+        let builder = WebDavClient::builder(BASE);
+        let debug = format!("{builder:?}");
+        assert!(!debug.contains("basic_auth"), "debug output: {debug}");
+        assert!(!debug.contains("bearer_token"), "debug output: {debug}");
+        assert!(!debug.contains("proxy_basic_auth"), "debug output: {debug}");
+    }
+
+    #[test]
+    fn error_message_contains_timeout_hint() {
+        let result = WebDavClient::builder(BASE).timeout(Duration::ZERO).build();
+        let err = match result {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            err.contains("timeout must be > 0"),
+            "error should mention timeout, got: {err}"
+        );
+    }
+
+    #[test]
+    fn error_message_contains_pool_hint() {
+        let result = WebDavClient::builder(BASE)
+            .pool_max_idle_per_host(0)
+            .build();
+        let err = match result {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            err.contains("pool_max_idle_per_host must be > 0"),
+            "error should mention pool_max_idle_per_host, got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_with_basic_auth_works() {
+        let client = WebDavClient::new(BASE, Some("user"), Some("pass")).unwrap();
+        let header = client.auth_header().expect("auth header present");
+        assert_eq!(header.to_str().unwrap(), "Basic dXNlcjpwYXNz");
     }
 }

--- a/src/webdav/builder.rs
+++ b/src/webdav/builder.rs
@@ -4,11 +4,21 @@
 use anyhow::{Result, anyhow};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as B64;
+use bytes::Bytes;
+use http_body_util::Full;
 use hyper::{Uri, header};
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::connect::proxy::Tunnel;
+use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use hyper_util::rt::TokioExecutor;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, RootCertStore};
+use rustls_native_certs::load_native_certs;
+use std::sync::Arc;
 use std::time::Duration;
 use zeroize::Zeroize;
 
-use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, build_hyper_client_full};
+use crate::common::http::{DEFAULT_POOL_MAX_IDLE_PER_HOST, HyperClient, MaybeProxied};
 use crate::webdav::client::{RequestCompressionMode, WebDavClient};
 
 /// Default request timeout applied when [`WebDavClientBuilder::timeout`] is
@@ -301,7 +311,7 @@ impl WebDavClientBuilder {
             None => None,
         };
 
-        let hyper_client = build_hyper_client_full(
+        let hyper_client = build_hyper_client(
             self.pool_max_idle_per_host,
             self.pool_idle_timeout,
             self.force_http1,
@@ -365,6 +375,177 @@ fn build_basic_auth_header(user: &str, pass: &str) -> Result<header::HeaderValue
     token.zeroize();
     val.zeroize();
     Ok(header_value?)
+}
+
+// ---------------------------------------------------------------------------
+// TLS configuration
+// ---------------------------------------------------------------------------
+
+/// A certificate verifier that accepts any server certificate.
+///
+/// # Warning
+///
+/// This completely disables TLS certificate verification. Only use in
+/// testing/debug scenarios — never in production.
+#[derive(Debug)]
+struct NoVerify;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer,
+        _intermediates: &[CertificateDer],
+        _server_name: &ServerName,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Build a rustls `ClientConfig` with native roots (fallback webpki),
+/// optional extra PEM trust roots, and optional danger mode.
+fn build_rustls_config(
+    extra_root_certs_pem: &[Vec<u8>],
+    danger_accept_invalid_certs: bool,
+) -> Result<ClientConfig> {
+    if danger_accept_invalid_certs {
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "fast-dav-rs: WARNING — danger_accept_invalid_certs is enabled, \
+             TLS certificate verification is disabled"
+        );
+
+        let config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth();
+        return Ok(config);
+    }
+
+    let mut roots = RootCertStore::empty();
+
+    match load_native_certs() {
+        result if !result.certs.is_empty() => {
+            for cert in result.certs {
+                let _ = roots.add(cert);
+            }
+        }
+        result => {
+            if !result.errors.is_empty() {
+                #[cfg(debug_assertions)]
+                eprintln!(
+                    "fast-dav-rs: falling back to webpki roots (native roots errors: {:?})",
+                    result.errors
+                );
+            }
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        }
+    }
+
+    for pem in extra_root_certs_pem {
+        for cert in rustls_pemfile::certs(&mut pem.as_slice()) {
+            let cert = cert.map_err(|e| anyhow!("failed to parse PEM certificate: {e}"))?;
+            let _ = roots.add(cert);
+        }
+    }
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Hyper client construction
+// ---------------------------------------------------------------------------
+
+/// Build a fully configured Hyper client.
+///
+/// Constructs the connector (with optional proxy tunnel), the TLS config
+/// (with optional extra roots / danger mode), and the Hyper client with
+/// pool settings. Called by [`WebDavClientBuilder::build`].
+#[allow(clippy::too_many_arguments)]
+fn build_hyper_client(
+    pool_max_idle_per_host: usize,
+    pool_idle_timeout: Option<Duration>,
+    force_http1: bool,
+    connect_timeout: Option<Duration>,
+    proxy: Option<Uri>,
+    proxy_basic_user: Option<String>,
+    proxy_basic_pass: Option<String>,
+    extra_root_certs_pem: &[Vec<u8>],
+    danger_accept_invalid_certs: bool,
+) -> Result<HyperClient> {
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+    if let Some(t) = connect_timeout {
+        http.set_connect_timeout(Some(t));
+    }
+
+    let inner = match proxy {
+        Some(proxy_uri) => {
+            let mut tunnel = Tunnel::new(proxy_uri, http);
+            if let (Some(user), Some(pass)) = (proxy_basic_user, proxy_basic_pass) {
+                let basic = B64.encode(format!("{user}:{pass}"));
+                tunnel = tunnel.with_auth(
+                    format!("Basic {basic}")
+                        .parse()
+                        .map_err(|e| anyhow!("invalid proxy auth header: {e}"))?,
+                );
+            }
+            MaybeProxied::Tunneled(tunnel)
+        }
+        None => MaybeProxied::Direct(http),
+    };
+
+    let tls = build_rustls_config(extra_root_certs_pem, danger_accept_invalid_certs)?;
+
+    let https_builder = HttpsConnectorBuilder::new()
+        .with_tls_config(tls)
+        .https_or_http()
+        .enable_http1();
+
+    let https = if force_http1 {
+        https_builder.wrap_connector(inner)
+    } else {
+        https_builder.enable_http2().wrap_connector(inner)
+    };
+
+    let mut builder = Client::builder(TokioExecutor::new());
+    if !force_http1 {
+        builder.http2_adaptive_window(true);
+    }
+    builder.pool_max_idle_per_host(pool_max_idle_per_host);
+    if let Some(t) = pool_idle_timeout {
+        builder.pool_idle_timeout(t);
+    }
+
+    Ok(builder.build::<_, Full<Bytes>>(https))
 }
 
 #[cfg(test)]

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -163,15 +163,9 @@ impl WebDavClient {
         }
     }
 
-    /// Get the default per-request timeout.
-    #[allow(dead_code)]
-    pub(crate) fn default_timeout(&self) -> Duration {
-        self.default_timeout
-    }
-
     /// Get the auth header value, if credentials were provided.
-    #[allow(dead_code)]
-    pub(crate) fn basic_auth_header(&self) -> Option<&header::HeaderValue> {
+    #[cfg(test)]
+    pub(crate) fn auth_header(&self) -> Option<&header::HeaderValue> {
         self.auth_header.as_ref()
     }
 
@@ -272,6 +266,10 @@ impl WebDavClient {
             .request_compression_mode
             .read()
             .unwrap_or_else(PoisonError::into_inner);
+        self.resolve_request_encoding_with_mode(&mode)
+    }
+
+    fn resolve_request_encoding_with_mode(&self, mode: &RequestCompressionMode) -> ContentEncoding {
         match *mode {
             RequestCompressionMode::Disabled => ContentEncoding::Identity,
             RequestCompressionMode::Force(enc) => enc,
@@ -427,15 +425,12 @@ impl WebDavClient {
         payload: Bytes,
         headers: &mut HeaderMap,
     ) -> (Bytes, Option<ContentEncoding>) {
-        if self
+        let mode = *self
             .request_compression_mode
             .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .is_auto()
-        {
-            // Recover from poisoning (here and below): the guarded value is a
-            // plain `Option<ContentEncoding>` that cannot be left logically
-            // inconsistent, so taking over the poisoned guard is safe.
+            .unwrap_or_else(PoisonError::into_inner);
+
+        if mode.is_auto() {
             let negotiated = *self
                 .negotiated_request_compression
                 .read()
@@ -454,7 +449,7 @@ impl WebDavClient {
 
         headers.remove(header::CONTENT_ENCODING);
 
-        let encoding = self.resolve_request_encoding();
+        let encoding = self.resolve_request_encoding_with_mode(&mode);
         if encoding == ContentEncoding::Identity {
             return (payload, None);
         }

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -1,6 +1,4 @@
 use anyhow::{Result, anyhow};
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as B64;
 use bytes::Bytes;
 use futures::{StreamExt, stream::FuturesOrdered};
 use http_body_util::Full;
@@ -9,13 +7,13 @@ use hyper::{HeaderMap, Method, Request, Response, StatusCode, Uri, header};
 use std::sync::{Arc, PoisonError, RwLock};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::time::{Duration, timeout};
-use zeroize::Zeroize;
 
 use crate::common::compression::{
     ContentEncoding, add_accept_encoding, add_content_encoding, compress_payload, decompress_body,
     detect_encodings, detect_request_compression_preference,
 };
-use crate::common::http::{HyperClient, build_hyper_client};
+use crate::common::http::HyperClient;
+use crate::webdav::builder::WebDavClientBuilder;
 use crate::webdav::types::{BatchItem, Depth};
 
 /// Strategy for compressing outgoing request bodies.
@@ -91,7 +89,9 @@ pub struct WebDavClient {
     /// trade-off so the header can be attached cheaply to each request.
     auth_header: Option<header::HeaderValue>,
     default_timeout: Duration,
-    request_compression_mode: RequestCompressionMode,
+    request_compression_mode: Arc<RwLock<RequestCompressionMode>>,
+    /// Pre-parsed `User-Agent` header injected on every request, if set.
+    user_agent: Option<header::HeaderValue>,
     negotiated_request_compression: Arc<RwLock<Option<ContentEncoding>>>,
     request_compression_probe: Arc<Mutex<()>>,
 }
@@ -109,41 +109,82 @@ impl WebDavClient {
     /// network path. Always use `https://` outside isolated test environments
     /// (e.g. a local Docker test server).
     pub fn new(base_url: &str, basic_user: Option<&str>, basic_pass: Option<&str>) -> Result<Self> {
-        let client = build_hyper_client()?;
+        let mut builder = Self::builder(base_url);
+        if let (Some(u), Some(p)) = (basic_user, basic_pass) {
+            builder = builder.basic_auth(u, p);
+        }
+        builder.build()
+    }
 
-        let base: Uri = base_url.parse()?;
-        let auth_header = if let (Some(u), Some(p)) = (basic_user, basic_pass) {
-            // Build the header value, then zeroize the intermediate strings so
-            // plaintext credentials do not linger in freed heap memory.
-            let mut token = format!("{}:{}", u, p);
-            let mut val = format!("Basic {}", B64.encode(&token));
-            let header_value = header::HeaderValue::from_str(&val);
-            token.zeroize();
-            val.zeroize();
-            Some(header_value?)
-        } else {
-            None
-        };
+    /// Create a builder for configuring the client before construction.
+    ///
+    /// Only the base URL is required; every other option has a sensible
+    /// default documented on [`WebDavClientBuilder`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use fast_dav_rs::webdav::WebDavClient;
+    /// use std::time::Duration;
+    ///
+    /// let client = WebDavClient::builder("https://dav.example.com/")
+    ///     .basic_auth("user", "pass")
+    ///     .timeout(Duration::from_secs(10))
+    ///     .build()?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn builder(base_url: impl Into<String>) -> WebDavClientBuilder {
+        WebDavClientBuilder::new(base_url)
+    }
 
-        Ok(Self {
+    /// Construct a client from pre-built parts.
+    ///
+    /// This is the internal constructor used by [`WebDavClient::new`] and
+    /// [`WebDavClientBuilder::build`].
+    pub(crate) fn from_parts(
+        base: Uri,
+        client: HyperClient,
+        auth_header: Option<header::HeaderValue>,
+        user_agent: Option<header::HeaderValue>,
+        default_timeout: Duration,
+        request_compression_mode: RequestCompressionMode,
+    ) -> Self {
+        Self {
             base,
             client,
             auth_header,
-            default_timeout: Duration::from_secs(20),
-            request_compression_mode: RequestCompressionMode::Auto,
+            user_agent,
+            default_timeout,
+            request_compression_mode: Arc::new(RwLock::new(request_compression_mode)),
             negotiated_request_compression: Arc::new(RwLock::new(None)),
             request_compression_probe: Arc::new(Mutex::new(())),
-        })
+        }
+    }
+
+    /// Get the default per-request timeout.
+    #[allow(dead_code)] // used by builder in Task 5
+    pub(crate) fn default_timeout(&self) -> Duration {
+        self.default_timeout
+    }
+
+    /// Get the Basic auth header value, if credentials were provided.
+    #[allow(dead_code)] // used by builder tests
+    pub(crate) fn basic_auth_header(&self) -> Option<&header::HeaderValue> {
+        self.auth_header.as_ref()
     }
 
     /// Configure request compression for this client.
-    pub fn set_request_compression(&mut self, encoding: ContentEncoding) {
+    pub fn set_request_compression(&self, encoding: ContentEncoding) {
         self.set_request_compression_mode(RequestCompressionMode::Force(encoding));
     }
 
     /// Configure the request compression strategy.
-    pub fn set_request_compression_mode(&mut self, mode: RequestCompressionMode) {
-        self.request_compression_mode = mode;
+    pub fn set_request_compression_mode(&self, mode: RequestCompressionMode) {
+        let mut guard = self
+            .request_compression_mode
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        *guard = mode;
         match mode {
             RequestCompressionMode::Auto => self.set_negotiated_encoding(None),
             RequestCompressionMode::Disabled => {
@@ -154,18 +195,21 @@ impl WebDavClient {
     }
 
     /// Enable adaptive request compression (default behaviour).
-    pub fn set_request_compression_auto(&mut self) {
+    pub fn set_request_compression_auto(&self) {
         self.set_request_compression_mode(RequestCompressionMode::Auto);
     }
 
     /// Disable request compression entirely.
-    pub fn disable_request_compression(&mut self) {
+    pub fn disable_request_compression(&self) {
         self.set_request_compression_mode(RequestCompressionMode::Disabled);
     }
 
     /// Get the current request compression strategy.
     pub fn request_compression_mode(&self) -> RequestCompressionMode {
-        self.request_compression_mode
+        *self
+            .request_compression_mode
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Get the currently resolved request compression encoding.
@@ -222,18 +266,18 @@ impl WebDavClient {
     }
 
     fn resolve_request_encoding(&self) -> ContentEncoding {
-        match self.request_compression_mode {
+        let mode = self
+            .request_compression_mode
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        match *mode {
             RequestCompressionMode::Disabled => ContentEncoding::Identity,
             RequestCompressionMode::Force(enc) => enc,
-            RequestCompressionMode::Auto => {
-                // Recover from poisoning: the guarded value is a plain
-                // `Option<ContentEncoding>` that cannot be left logically
-                // inconsistent, so taking over the poisoned guard is safe.
-                self.negotiated_request_compression
-                    .read()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .unwrap_or(AUTO_DEFAULT_ENCODING)
-            }
+            RequestCompressionMode::Auto => self
+                .negotiated_request_compression
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .unwrap_or(AUTO_DEFAULT_ENCODING),
         }
     }
 
@@ -255,7 +299,12 @@ impl WebDavClient {
     /// and keeps gzip — proven to work by the probe — otherwise. On failure,
     /// request compression is disabled (identity).
     async fn probe_request_compression_support(&self) {
-        if !self.request_compression_mode.is_auto() {
+        if !self
+            .request_compression_mode
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_auto()
+        {
             return;
         }
 
@@ -344,7 +393,12 @@ impl WebDavClient {
         attempted: Option<ContentEncoding>,
         status: StatusCode,
     ) -> bool {
-        if !self.request_compression_mode.is_auto() {
+        if !self
+            .request_compression_mode
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_auto()
+        {
             return false;
         }
 
@@ -371,7 +425,12 @@ impl WebDavClient {
         payload: Bytes,
         headers: &mut HeaderMap,
     ) -> (Bytes, Option<ContentEncoding>) {
-        if self.request_compression_mode.is_auto() {
+        if self
+            .request_compression_mode
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_auto()
+        {
             // Recover from poisoning (here and below): the guarded value is a
             // plain `Option<ContentEncoding>` that cannot be left logically
             // inconsistent, so taking over the poisoned guard is safe.
@@ -452,6 +511,10 @@ impl WebDavClient {
                 req_builder = req_builder.header(header::AUTHORIZATION, auth_header);
             }
 
+            if let Some(ua) = &self.user_agent {
+                headers.insert(header::USER_AGENT, ua.clone());
+            }
+
             let mut final_body: Option<Bytes> = None;
             let mut attempted_encoding: Option<ContentEncoding> = None;
 
@@ -524,6 +587,10 @@ impl WebDavClient {
 
             if let Some(ref auth_header) = auth {
                 req_builder = req_builder.header(header::AUTHORIZATION, auth_header);
+            }
+
+            if let Some(ua) = &self.user_agent {
+                headers.insert(header::USER_AGENT, ua.clone());
             }
 
             let mut final_body: Option<Bytes> = None;
@@ -926,5 +993,36 @@ impl WebDavClient {
             None,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::compression::ContentEncoding;
+
+    const BASE: &str = "https://dav.example.com/user01/";
+
+    #[test]
+    fn clone_shares_compression_mode() {
+        let client_a = WebDavClient::new(BASE, None, None).unwrap();
+        let client_b = client_a.clone();
+
+        client_a.set_request_compression_mode(RequestCompressionMode::Force(ContentEncoding::Zstd));
+
+        assert_eq!(
+            client_b.request_compression_mode(),
+            RequestCompressionMode::Force(ContentEncoding::Zstd)
+        );
+    }
+
+    #[test]
+    fn set_compression_does_not_require_mut() {
+        let client = WebDavClient::new(BASE, None, None).unwrap();
+        client.set_request_compression_mode(RequestCompressionMode::Disabled);
+        assert_eq!(
+            client.request_compression_mode(),
+            RequestCompressionMode::Disabled
+        );
     }
 }

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -17,11 +17,12 @@ use crate::webdav::builder::WebDavClientBuilder;
 use crate::webdav::types::{BatchItem, Depth};
 
 /// Strategy for compressing outgoing request bodies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum RequestCompressionMode {
     /// Negotiate automatically: attempt gzip on first use, honor the server's advertised
     /// `Accept-Encoding` preference on success, and cache the result; fall back to identity
     /// on 415/501.
+    #[default]
     Auto,
     Disabled,
     Force(ContentEncoding),

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -162,13 +162,13 @@ impl WebDavClient {
     }
 
     /// Get the default per-request timeout.
-    #[allow(dead_code)] // used by builder in Task 5
+    #[allow(dead_code)]
     pub(crate) fn default_timeout(&self) -> Duration {
         self.default_timeout
     }
 
     /// Get the Basic auth header value, if credentials were provided.
-    #[allow(dead_code)] // used by builder tests
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn basic_auth_header(&self) -> Option<&header::HeaderValue> {
         self.auth_header.as_ref()
     }

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -79,14 +79,15 @@ fn is_etag_character(byte: u8) -> bool {
 pub struct WebDavClient {
     base: Uri,
     client: HyperClient,
-    /// Pre-built `Authorization: Basic …` value attached to every request, if
-    /// credentials were provided.
+    /// Pre-built `Authorization` header (Basic or Bearer) attached to every
+    /// request, if credentials were provided.
     ///
-    /// Residual limitation: the intermediate credential strings are zeroized in
-    /// [`WebDavClient::new`], but this `HeaderValue` necessarily keeps a Base64
-    /// copy of the credentials in memory for the whole lifetime of the client
-    /// (and its clones) and is **not** zeroized on drop. This is an accepted
-    /// trade-off so the header can be attached cheaply to each request.
+    /// Residual limitation: the intermediate credential strings are zeroized
+    /// in [`WebDavClientBuilder::build`], but this `HeaderValue` necessarily
+    /// keeps a copy of the credentials in memory for the whole lifetime of
+    /// the client (and its clones) and is **not** zeroized on drop. This is
+    /// an accepted trade-off so the header can be attached cheaply to each
+    /// request.
     auth_header: Option<header::HeaderValue>,
     default_timeout: Duration,
     request_compression_mode: Arc<RwLock<RequestCompressionMode>>,

--- a/src/webdav/client.rs
+++ b/src/webdav/client.rs
@@ -168,8 +168,8 @@ impl WebDavClient {
         self.default_timeout
     }
 
-    /// Get the Basic auth header value, if credentials were provided.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Get the auth header value, if credentials were provided.
+    #[allow(dead_code)]
     pub(crate) fn basic_auth_header(&self) -> Option<&header::HeaderValue> {
         self.auth_header.as_ref()
     }

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -1,8 +1,10 @@
+pub mod builder;
 pub mod client;
 pub(crate) mod streaming;
 pub mod types;
 pub mod xml;
 
+pub use builder::WebDavClientBuilder;
 pub use client::{RequestCompressionMode, WebDavClient};
 pub use types::{BatchItem, DavItemCommon, Depth};
 pub use xml::{build_sync_collection_body, escape_xml};

--- a/tests/e2e/caldav/compression/compression_tests.rs
+++ b/tests/e2e/caldav/compression/compression_tests.rs
@@ -22,7 +22,7 @@ async fn test_compression_support() {
     ];
 
     for encoding in encodings {
-        let mut client_with_encoding = client.clone();
+        let client_with_encoding = client.clone();
         client_with_encoding.set_request_compression(encoding);
 
         // Test a simple GET request

--- a/tests/e2e/carddav/compression/compression_tests.rs
+++ b/tests/e2e/carddav/compression/compression_tests.rs
@@ -23,7 +23,7 @@ async fn test_compression_support() {
     ];
 
     for encoding in encodings {
-        let mut client_with_encoding = client.clone();
+        let client_with_encoding = client.clone();
         client_with_encoding.set_request_compression(encoding);
 
         let response = client_with_encoding.get("").await;

--- a/tests/unit/caldav/client_tests.rs
+++ b/tests/unit/caldav/client_tests.rs
@@ -365,3 +365,62 @@ async fn test_calendar_query_timerange_rejects_malformed_end() {
         .expect_err("malformed end must be rejected before any request");
     assert!(err.to_string().contains("invalid calendar-query end"));
 }
+
+#[test]
+fn builder_propagates_options() {
+    use fast_dav_rs::RequestCompressionMode;
+    use std::time::Duration;
+
+    let client = CalDavClient::builder("https://cal.example.com/dav/")
+        .basic_auth("user", "pass")
+        .timeout(Duration::from_secs(3))
+        .pool_max_idle_per_host(8)
+        .request_compression(RequestCompressionMode::Force(
+            fast_dav_rs::ContentEncoding::Gzip,
+        ))
+        .build()
+        .expect("build succeeds");
+
+    assert_eq!(
+        client.request_compression_mode(),
+        RequestCompressionMode::Force(fast_dav_rs::ContentEncoding::Gzip)
+    );
+    assert_eq!(
+        client.request_compression(),
+        fast_dav_rs::ContentEncoding::Gzip
+    );
+}
+
+#[test]
+fn builder_invalid_url() {
+    let result = CalDavClient::builder("not a valid url").build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn builder_bearer_auth() {
+    let client = CalDavClient::builder("https://cal.example.com/dav/")
+        .bearer_token("test-token")
+        .build()
+        .expect("build succeeds");
+    // We can't directly access the auth header from CalDavClient,
+    // but we verified it compiles and builds successfully.
+    let _ = client;
+}
+
+#[test]
+fn clone_shares_compression_mode() {
+    use fast_dav_rs::RequestCompressionMode;
+
+    let client_a = CalDavClient::builder("https://cal.example.com/dav/")
+        .build()
+        .unwrap();
+    let client_b = client_a.clone();
+
+    client_a.set_request_compression_mode(RequestCompressionMode::Disabled);
+
+    assert_eq!(
+        client_b.request_compression_mode(),
+        RequestCompressionMode::Disabled
+    );
+}

--- a/tests/unit/caldav/etag_tests.rs
+++ b/tests/unit/caldav/etag_tests.rs
@@ -96,7 +96,7 @@ async fn test_conditional_operations_normalize_if_match() {
         ("*", "*"),
     ] {
         let (base_url, request) = capture_request().await;
-        let mut client = CalDavClient::new(&base_url, None, None).unwrap();
+        let client = CalDavClient::new(&base_url, None, None).unwrap();
         client.disable_request_compression();
         client
             .put_if_match("event.ics", Bytes::from_static(b"BEGIN:VCALENDAR"), etag)
@@ -107,7 +107,7 @@ async fn test_conditional_operations_normalize_if_match() {
         assert_if_match_header(&request, expected);
 
         let (base_url, request) = capture_request().await;
-        let mut client = CalDavClient::new(&base_url, None, None).unwrap();
+        let client = CalDavClient::new(&base_url, None, None).unwrap();
         client.disable_request_compression();
         client.delete_if_match("event.ics", etag).await.unwrap();
         let request = request.await.unwrap();

--- a/tests/unit/carddav/client_tests.rs
+++ b/tests/unit/carddav/client_tests.rs
@@ -291,3 +291,60 @@ fn test_map_sync_response() {
     );
     assert!(response.items[1].is_deleted); // Should be marked as deleted
 }
+
+#[test]
+fn builder_propagates_options() {
+    use fast_dav_rs::RequestCompressionMode;
+    use std::time::Duration;
+
+    let client = CardDavClient::builder("https://card.example.com/dav/")
+        .basic_auth("user", "pass")
+        .timeout(Duration::from_secs(3))
+        .pool_max_idle_per_host(8)
+        .request_compression(RequestCompressionMode::Force(
+            fast_dav_rs::ContentEncoding::Gzip,
+        ))
+        .build()
+        .expect("build succeeds");
+
+    assert_eq!(
+        client.request_compression_mode(),
+        RequestCompressionMode::Force(fast_dav_rs::ContentEncoding::Gzip)
+    );
+    assert_eq!(
+        client.request_compression(),
+        fast_dav_rs::ContentEncoding::Gzip
+    );
+}
+
+#[test]
+fn builder_invalid_url() {
+    let result = CardDavClient::builder("not a valid url").build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn builder_bearer_auth() {
+    let client = CardDavClient::builder("https://card.example.com/dav/")
+        .bearer_token("test-token")
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn clone_shares_compression_mode() {
+    use fast_dav_rs::RequestCompressionMode;
+
+    let client_a = CardDavClient::builder("https://card.example.com/dav/")
+        .build()
+        .unwrap();
+    let client_b = client_a.clone();
+
+    client_a.set_request_compression_mode(RequestCompressionMode::Disabled);
+
+    assert_eq!(
+        client_b.request_compression_mode(),
+        RequestCompressionMode::Disabled
+    );
+}

--- a/tests/unit/carddav/etag_tests.rs
+++ b/tests/unit/carddav/etag_tests.rs
@@ -96,7 +96,7 @@ async fn test_conditional_operations_normalize_if_match() {
         ("*", "*"),
     ] {
         let (base_url, request) = capture_request().await;
-        let mut client = CardDavClient::new(&base_url, None, None).unwrap();
+        let client = CardDavClient::new(&base_url, None, None).unwrap();
         client.disable_request_compression();
         client
             .put_if_match("contact.vcf", Bytes::from_static(b"BEGIN:VCARD"), etag)
@@ -107,7 +107,7 @@ async fn test_conditional_operations_normalize_if_match() {
         assert_if_match_header(&request, expected);
 
         let (base_url, request) = capture_request().await;
-        let mut client = CardDavClient::new(&base_url, None, None).unwrap();
+        let client = CardDavClient::new(&base_url, None, None).unwrap();
         client.disable_request_compression();
         client.delete_if_match("contact.vcf", etag).await.unwrap();
         let request = request.await.unwrap();

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,3 +1,4 @@
 pub mod caldav;
 pub mod carddav;
 pub mod common;
+pub mod webdav;

--- a/tests/unit/webdav/builder_tests.rs
+++ b/tests/unit/webdav/builder_tests.rs
@@ -1,0 +1,174 @@
+use fast_dav_rs::{ContentEncoding, RequestCompressionMode, WebDavClient};
+use std::str::FromStr;
+use std::time::Duration;
+
+const BASE: &str = "https://dav.example.com/user01/";
+
+#[test]
+fn builder_defaults() {
+    let client = WebDavClient::builder(BASE).build().expect("build succeeds");
+    assert_eq!(
+        client.request_compression_mode(),
+        RequestCompressionMode::Auto
+    );
+}
+
+#[test]
+fn builder_basic_auth() {
+    let client = WebDavClient::builder(BASE)
+        .basic_auth("user", "pass")
+        .build()
+        .expect("build succeeds");
+    // Verifying via the public API: the client builds successfully
+    let _ = client;
+}
+
+#[test]
+fn builder_bearer_auth() {
+    let client = WebDavClient::builder(BASE)
+        .bearer_token("token123")
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_auth_last_wins() {
+    let client = WebDavClient::builder(BASE)
+        .basic_auth("user", "pass")
+        .bearer_token("token")
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_no_auth() {
+    let client = WebDavClient::builder(BASE).build().expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_invalid_url_errors() {
+    assert!(WebDavClient::builder("not a url").build().is_err());
+}
+
+#[test]
+fn builder_timeout_zero_errors() {
+    assert!(
+        WebDavClient::builder(BASE)
+            .timeout(Duration::ZERO)
+            .build()
+            .is_err()
+    );
+}
+
+#[test]
+fn builder_pool_zero_errors() {
+    assert!(
+        WebDavClient::builder(BASE)
+            .pool_max_idle_per_host(0)
+            .build()
+            .is_err()
+    );
+}
+
+#[test]
+fn builder_clone_shares_compression() {
+    let client_a = WebDavClient::builder(BASE)
+        .request_compression(RequestCompressionMode::Force(ContentEncoding::Zstd))
+        .build()
+        .unwrap();
+    let client_b = client_a.clone();
+
+    client_a.set_request_compression_mode(RequestCompressionMode::Disabled);
+
+    assert_eq!(
+        client_b.request_compression_mode(),
+        RequestCompressionMode::Disabled
+    );
+}
+
+#[test]
+fn builder_set_compression_without_mut() {
+    let client = WebDavClient::builder(BASE).build().unwrap();
+    // This should compile without `mut`
+    client.set_request_compression_mode(RequestCompressionMode::Disabled);
+    assert_eq!(
+        client.request_compression_mode(),
+        RequestCompressionMode::Disabled
+    );
+}
+
+#[test]
+fn builder_force_http1() {
+    let client = WebDavClient::builder(BASE)
+        .force_http1(true)
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_with_proxy() {
+    let client = WebDavClient::builder(BASE)
+        .proxy(hyper::Uri::from_str("http://127.0.0.1:9090").unwrap())
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_with_proxy_auth() {
+    let client = WebDavClient::builder(BASE)
+        .proxy(hyper::Uri::from_str("http://127.0.0.1:9090").unwrap())
+        .proxy_basic_auth("proxyuser", "proxypass")
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_danger_accept_invalid_certs() {
+    let client = WebDavClient::builder(BASE)
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_user_agent() {
+    let client = WebDavClient::builder(BASE)
+        .user_agent("MyApp/1.0")
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_connect_timeout() {
+    let client = WebDavClient::builder(BASE)
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_pool_idle_timeout() {
+    let client = WebDavClient::builder(BASE)
+        .pool_idle_timeout(Duration::from_secs(90))
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}
+
+#[test]
+fn builder_extra_root_certs_empty() {
+    let client = WebDavClient::builder(BASE)
+        .extra_root_certs_pem(vec![])
+        .build()
+        .expect("build succeeds");
+    let _ = client;
+}

--- a/tests/unit/webdav/mod.rs
+++ b/tests/unit/webdav/mod.rs
@@ -1,0 +1,1 @@
+pub mod builder_tests;


### PR DESCRIPTION

### Builder pattern for client configuration

Introduce WebDavClientBuilder, CalDavClientBuilder, and CardDavClientBuilder to replace ad-hoc client construction with a fluent, validated API.

#### What's included
- TLS configuration: native cert loading, extra root certs, optional danger_accept_invalid_certs
- Proxy tunneling: HTTP(S) proxy support with optional Basic auth
- Auth: Basic and Bearer token, with credential redaction in Debug
- Connection pool tuning: max idle per host, idle timeout
- Request compression: selectable mode (Auto, Enabled, Disabled)
- Timeouts: request + connect timeouts, HTTP/1-only forcing

#### Why
Prior to this, callers had to assemble the hyper connector, TLS, proxy, and compression settings manually. The builder encapsulates that complexity behind a single ergonomic entry point (WebDavClient::builder()) with sensible Defaults and validation (e.g. non-empty auth, proxy auth pairing).